### PR TITLE
Generate code using the ast module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v5

--- a/apywire/__init__.py
+++ b/apywire/__init__.py
@@ -5,19 +5,13 @@
 """A package to wire up objects."""
 
 from .wiring import (
-    Blueprint,
     InstanceData,
     Spec,
-    Wired,
-    compile,
-    wire,
+    Wiring,
 )
 
 __all__ = [
-    "Blueprint",
     "InstanceData",
     "Spec",
-    "Wired",
-    "compile",
-    "wire",
+    "Wiring",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,12 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = []
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 [project.urls]
 Homepage = "https://github.com/alganet/apywire"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -3,9 +3,15 @@
 # SPDX-License-Identifier: ISC
 
 import datetime
+from textwrap import dedent
 from typing import Protocol
 
+import black
+
 import apywire
+
+THREE_INDENTS = 12
+BLACK_MODE = black.FileMode(line_length=79 - THREE_INDENTS)
 
 
 def test_simple_load_constructor_args() -> None:
@@ -16,7 +22,7 @@ def test_simple_load_constructor_args() -> None:
             "year": 2003,
         }
     }
-    wired: apywire.Wired = apywire.wire(spec)
+    wired: apywire.Wiring = apywire.Wiring(spec)
     instance = wired.yearsAgo
     assert isinstance(instance, datetime.datetime)
     assert instance.year == 2003
@@ -27,10 +33,28 @@ def test_simple_load_constructor_args() -> None:
 
 def test_simple_raise_on_nonexistent_wired_attribute() -> None:
     try:
-        apywire.wire({}).nonexistent
+        apywire.Wiring({}).nonexistent
         assert False, "Should have raised AttributeError"
     except AttributeError as e:
         assert "no attribute 'nonexistent'" in str(e)
+
+
+def test_empty_class_compiled() -> None:
+    wired: apywire.Wiring = apywire.Wiring({})
+    pythonCode = wired.compile()
+    pythonCode = black.format_str(pythonCode, mode=BLACK_MODE)
+    assert (
+        dedent(
+            """\
+        class Compiled:
+            pass
+
+
+        compiled = Compiled()
+        """
+        )
+        == pythonCode
+    )
 
 
 def test_simple_compile_constructor_args() -> None:
@@ -42,15 +66,26 @@ def test_simple_compile_constructor_args() -> None:
         }
     }
 
-    pythonCode = apywire.compile(spec)
+    wired: apywire.Wiring = apywire.Wiring(spec)
+    pythonCode = wired.compile()
+    pythonCode = black.format_str(pythonCode, mode=BLACK_MODE)
     assert (
-        """import datetime
-class Compiled:
-    @property
-    def birthday(self):
-        return datetime.datetime(day=25, month=12, year=1990)
-compiled = Compiled()"""
-        in pythonCode
+        dedent(
+            """\
+            import datetime
+
+
+            class Compiled:
+
+                @property
+                def birthday(self):
+                    return datetime.datetime(day=25, month=12, year=1990)
+
+
+            compiled = Compiled()
+            """
+        )
+        == pythonCode
     )
 
     class MockHasBirthday(Protocol):
@@ -65,3 +100,84 @@ compiled = Compiled()"""
     assert instance.year == 1990
     assert instance.month == 12
     assert instance.day == 25
+
+
+def test_deep_module_paths() -> None:
+    """Test wiring with deeply nested module paths."""
+    import sys
+    from types import ModuleType
+
+    # Define typed mock modules
+    class SomeClass:
+        def __init__(self) -> None:
+            self.value = "deep mock"
+
+    class MockBatModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("foo.bar.baz.bat")
+            self.SomeClass = SomeClass
+
+    class MockBazModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("foo.bar.baz")
+            self.bat = MockBatModule()
+
+    class MockBarModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("foo.bar")
+            self.baz = MockBazModule()
+
+    class MockFooModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("foo")
+            self.bar = MockBarModule()
+
+    # Create and set mock modules
+    foo_mod = MockFooModule()
+    sys.modules["foo"] = foo_mod
+    sys.modules["foo.bar"] = foo_mod.bar
+    sys.modules["foo.bar.baz"] = foo_mod.bar.baz
+    sys.modules["foo.bar.baz.bat"] = foo_mod.bar.baz.bat
+
+    try:
+        spec: apywire.Spec = {"foo.bar.baz.bat.SomeClass someModule": {}}
+        wired: apywire.Wiring = apywire.Wiring(spec)
+        instance = wired.someModule
+        assert isinstance(instance, SomeClass)
+        assert instance.value == "deep mock"
+
+        # Test compilation
+        pythonCode = wired.compile()
+        pythonCode = black.format_str(pythonCode, mode=BLACK_MODE)
+        expected = dedent(
+            """\
+            import foo.bar.baz.bat
+
+
+            class Compiled:
+
+                @property
+                def someModule(self):
+                    return foo.bar.baz.bat.SomeClass()
+
+
+            compiled = Compiled()
+            """
+        )
+        assert expected == pythonCode
+
+        class MockHasSomeModule(Protocol):
+            someModule: SomeClass
+
+        # Test execution of compiled code
+        execd: dict[str, MockHasSomeModule] = {}
+        exec(pythonCode, execd)
+        compiled: MockHasSomeModule = execd["compiled"]
+        instance = compiled.someModule
+        assert isinstance(instance, SomeClass)
+        assert instance.value == "deep mock"
+    finally:
+        # Clean up mock modules
+        for mod in ["foo", "foo.bar", "foo.bar.baz", "foo.bar.baz.bat"]:
+            if mod in sys.modules:
+                del sys.modules[mod]


### PR DESCRIPTION
 - Code generated by the `compile` function now uses the ast module to do so.
 - In tests, we are now using dedent and black to format generated code to a predictable style, making assertions easier to write and maintain.

<!--
SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>

SPDX-License-Identifier: ISC
-->
## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass
- [x] Code formatted
- [ ] Documentation updated