### PR TITLE
Support constant interpolation

### DIFF
--- a/apywire/constants.py
+++ b/apywire/constants.py
@@ -19,6 +19,20 @@ PLACEHOLDER_START = "{"
 PLACEHOLDER_END = "}"
 """End marker for placeholder references in spec values."""
 
+# Placeholder regex pattern (compiled for efficiency)
+PLACEHOLDER_PATTERN = r"\{([^{}]+)\}"
+"""Regex pattern for matching placeholders like {name}.
+
+Matches placeholder syntax with the following rules:
+- Starts with { and ends with }
+- Captures the placeholder name (group 1)
+- Does not allow nested braces in the name
+- Example: "{host}" matches with name="host"
+"""
+
+SYNTHETIC_CONST = "__sconst__"
+"""Synthetic module name used to represent promoted constants."""
+
 # Cache attribute constants
 CACHE_ATTR_PREFIX = "_"
 """Prefix for cache attributes on compiled/runtime instances."""

--- a/apywire/wiring.py
+++ b/apywire/wiring.py
@@ -16,14 +16,19 @@ containers:
 
 from __future__ import annotations
 
+import re
+from collections import deque
 from types import EllipsisType
 from typing import TypeAlias, cast
 
 from apywire.constants import (
     PLACEHOLDER_END,
+    PLACEHOLDER_PATTERN,
     PLACEHOLDER_START,
     SPEC_KEY_DELIMITER,
+    SYNTHETIC_CONST,
 )
+from apywire.exceptions import CircularWiringError, UnknownPlaceholderError
 from apywire.threads import ThreadLocalState
 
 _ConstantValue: TypeAlias = (
@@ -88,7 +93,7 @@ Spec: TypeAlias = dict[str, _SpecMapping | _ConstantValue]
 
 # Type aliases for parsed spec entries
 _ParsedEntry: TypeAlias = tuple[
-    str, str, str | None, _ResolvedSpecMapping
+    str, str, str | None, _ResolvedSpecMapping | str | _WiredRef
 ]  # (module, class, factory_method, data)
 _UnresolvedParsedEntry: TypeAlias = tuple[
     str, str, str, str | None, _SpecMapping
@@ -129,9 +134,10 @@ class WiringBase:
         self._thread_safe = thread_safe
         self._max_lock_attempts = max_lock_attempts
         self._lock_retry_sleep = lock_retry_sleep
+        self._placeholder_pattern = re.compile(PLACEHOLDER_PATTERN)
 
         parsed: list[_UnresolvedParsedEntry] = []
-        consts: dict[str, _ConstantValue] = {}
+        consts: dict[str, _SpecMapping | _ConstantValue] = {}
 
         # First pass: classify entries into wired classes or constants
         for key, value in spec.items():
@@ -140,13 +146,9 @@ class WiringBase:
                 parsed.append(entry)
             else:
                 # It's a constant
-                consts[key] = cast(_ConstantValue, value)
+                consts[key] = value
 
-        # Merge constants into the initial runtime cache
-        self._values: dict[str, _RuntimeValue] = dict(consts)
-
-        # Resolve placeholders like "{name}" using _resolve.
-
+        # Parse wired objects first
         self._parsed: dict[str, _ParsedEntry] = {
             name: (
                 module_name,
@@ -156,7 +158,81 @@ class WiringBase:
             )
             for module_name, class_name, name, factory_method, value in parsed
         }
-        # Instances will be lazily instantiated and stored in self._values
+
+        # Classify constants by placeholder type
+        raw_consts: dict[str, _SpecMapping | _ConstantValue] = {}
+        const_with_refs: dict[
+            str, tuple[_SpecMapping | _ConstantValue, set[str]]
+        ] = {}
+
+        for key, value in consts.items():
+            placeholder_names = self._find_placeholder_names(value)
+            if not placeholder_names:
+                # No placeholders - store immediately
+                raw_consts[key] = value
+            else:
+                # Has placeholders - classify later
+                const_with_refs[key] = (value, placeholder_names)
+
+        # Separate constants with refs into const-only vs wired-object refs
+        # handling transitive promotion
+        const_deps_graph: dict[str, set[str]] = {
+            key: placeholder_names
+            for key, (value, placeholder_names) in const_with_refs.items()
+        }
+        # Initially, mark constants that directly reference a wired object
+        to_promote = set()
+        for key, (value, placeholder_names) in const_with_refs.items():
+            if any(name in self._parsed for name in placeholder_names):
+                to_promote.add(key)
+        # Propagate promotion transitively
+        changed = True
+        while changed:
+            changed = False
+            for key, deps in const_deps_graph.items():
+                if key in to_promote:
+                    continue
+                if any(dep in to_promote for dep in deps):
+                    to_promote.add(key)
+                    changed = True
+        # Now, split into promoted and pure-constant refs
+        const_with_const_refs: dict[str, _SpecMapping | _ConstantValue] = {}
+        const_with_wired_refs: dict[str, _SpecMapping | _ConstantValue] = {}
+        for key, (value, placeholder_names) in const_with_refs.items():
+            if key in to_promote:
+                const_with_wired_refs[key] = value
+            else:
+                const_with_const_refs[key] = value
+
+        # Topologically sort and expand constant-only refs
+        if const_with_const_refs:
+            const_deps = {
+                k: self._find_placeholder_names(v)
+                for k, v in const_with_const_refs.items()
+            }
+            sorted_const_keys = self._topological_sort(const_deps)
+        else:
+            sorted_const_keys = []
+
+        # Resolve constants in dependency order
+        resolved_consts: dict[str, _RuntimeValue] = dict(raw_consts)
+        for key in sorted_const_keys:
+            resolved = self._resolve_constant(
+                const_with_const_refs[key], resolved_consts
+            )
+            resolved_consts[key] = resolved
+
+        self._values: dict[str, _RuntimeValue] = resolved_consts
+
+        # Create synthetic parsed entries for auto-promoted constants
+        for key, value in const_with_wired_refs.items():
+            # Create a synthetic entry that will format the string at runtime
+            self._parsed[key] = (
+                SYNTHETIC_CONST,  # Synthetic module marker
+                "str",  # Will use string formatting
+                None,  # No factory method
+                cast(str | _WiredRef, self._resolve(value)),
+            )
         if self._thread_safe:
             # Thread-safe mode: use mixin helpers for lock state.
             # Note: Derived classes must implement _init_thread_safety
@@ -212,6 +288,18 @@ class WiringBase:
         """Check if a string is a placeholder reference like '{name}'."""
         return s.startswith(PLACEHOLDER_START) and s.endswith(PLACEHOLDER_END)
 
+    def _extract_placeholder_name(self, s: str) -> str:
+        """Extract the name from a placeholder string like '{name}'.
+
+        Args:
+            s: Placeholder string (must be validated with
+               _is_placeholder first)
+
+        Returns:
+            The placeholder name without braces
+        """
+        return s[len(PLACEHOLDER_START) : -len(PLACEHOLDER_END)]
+
     def _resolve(self, obj: _SpecValue) -> _ResolvedValue:
         """Resolve placeholders into `_WiredRef` markers for runtime.
 
@@ -220,7 +308,7 @@ class WiringBase:
         """
         if isinstance(obj, str):
             if self._is_placeholder(obj):
-                ref_name = obj[len(PLACEHOLDER_START) : -len(PLACEHOLDER_END)]
+                ref_name = self._extract_placeholder_name(obj)
                 return _WiredRef(ref_name)
             return obj
         if isinstance(obj, dict):
@@ -230,3 +318,157 @@ class WiringBase:
         if isinstance(obj, tuple):
             return tuple(self._resolve(v) for v in obj)
         return obj
+
+    def _interpolate_placeholders(
+        self,
+        template: str,
+        lookup: dict[str, _RuntimeValue],
+        context: str = "",
+    ) -> str:
+        """Replace placeholders in a string template with values.
+
+        Args:
+            template: String containing placeholders like "{name}"
+            lookup: Dictionary mapping placeholder names to values
+            context: Optional context for error messages
+
+        Returns:
+            String with all placeholders replaced by their string values
+
+        Raises:
+            UnknownPlaceholderError: If placeholder name not in lookup
+        """
+
+        def replace_placeholder(match: re.Match[str]) -> str:
+            ref_name = match.group(1)
+            if ref_name not in lookup:
+                ctx_msg = f" in {context}" if context else ""
+                raise UnknownPlaceholderError(
+                    f"Unknown placeholder '{ref_name}'{ctx_msg}"
+                )
+            ref_value = lookup[ref_name]
+            return (
+                str(ref_value) if not isinstance(ref_value, str) else ref_value
+            )
+
+        return re.sub(self._placeholder_pattern, replace_placeholder, template)
+
+    def _find_placeholder_names(self, obj: _SpecValue) -> set[str]:
+        """Find all placeholder names referenced in a value.
+
+        Args:
+            obj: Value to search for placeholders
+
+        Returns:
+            Set of placeholder names found
+        """
+        names: set[str] = set()
+        if isinstance(obj, str):
+            # Find all placeholders in the string (embedded or not)
+            matches: list[str] = re.findall(self._placeholder_pattern, obj)
+            names.update(matches)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                names.update(self._find_placeholder_names(v))
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                names.update(self._find_placeholder_names(v))
+        return names
+
+    def _topological_sort(
+        self, dependencies: dict[str, set[str]]
+    ) -> list[str]:
+        """Topologically sort items by dependency order using Kahn's algorithm.
+
+        Args:
+            dependencies: Mapping of item names to their dependencies
+
+        Returns:
+            List of items in dependency order (dependencies first)
+
+        Raises:
+            CircularWiringError: If circular dependencies detected
+        """
+        # Calculate in-degree (number of dependencies) for each node
+        # Only count dependencies that are also in the set being sorted
+        in_degree: dict[str, int] = {}
+        for node, deps in dependencies.items():
+            # Filter to only dependencies within this set
+            internal_deps = deps & dependencies.keys()
+            in_degree[node] = len(internal_deps)
+
+        # Start with nodes that have no dependencies (within this set)
+        queue: deque[str] = deque(
+            [node for node, degree in in_degree.items() if degree == 0]
+        )
+        result: list[str] = []
+
+        while queue:
+            node = queue.popleft()
+            result.append(node)
+
+            # Find nodes that depend on this node (within this set)
+            for other_node, deps in dependencies.items():
+                if node in deps:
+                    in_degree[other_node] -= 1
+                    if in_degree[other_node] == 0:
+                        queue.append(other_node)
+
+        # If we couldn't process all nodes, there's a cycle
+        if len(result) != len(dependencies):
+            # Find nodes in cycle for error message
+            unprocessed = [n for n in dependencies if n not in result]
+            raise CircularWiringError(
+                f"Circular dependency detected in constants: "
+                f"{', '.join(unprocessed)}"
+            )
+
+        return result
+
+    def _resolve_constant(
+        self, value: _SpecValue, resolved: dict[str, _RuntimeValue]
+    ) -> _RuntimeValue:
+        """Resolve a constant value, expanding ONLY constant placeholders.
+
+        Constant placeholders are expanded immediately. Wired object
+        placeholders should not appear here as those constants are
+        auto-promoted to accessors.
+
+        Args:
+            value: Constant value to resolve
+            resolved: Already-resolved constants available for reference
+
+        Returns:
+            Fully resolved constant value
+
+        Raises:
+            UnknownPlaceholderError: If placeholder references unknown constant
+        """
+        if isinstance(value, str):
+            # Check if the entire string is a single placeholder
+            if self._is_placeholder(value):
+                ref_name = self._extract_placeholder_name(value)
+                if ref_name not in resolved:
+                    raise UnknownPlaceholderError(
+                        f"Unknown constant placeholder '{ref_name}'"
+                    )
+                # Return the resolved value directly
+                ref_value = resolved[ref_name]
+                return (
+                    str(ref_value)
+                    if not isinstance(ref_value, str)
+                    else ref_value
+                )
+
+            # Handle embedded placeholders via string interpolation
+            return self._interpolate_placeholders(value, resolved, "constant")
+        if isinstance(value, dict):
+            return {
+                k: self._resolve_constant(v, resolved)
+                for k, v in value.items()
+            }
+        if isinstance(value, list):
+            return [self._resolve_constant(v, resolved) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self._resolve_constant(v, resolved) for v in value)
+        return value

--- a/tests/test_constant_placeholders.py
+++ b/tests/test_constant_placeholders.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+"""Tests for placeholder expansion in constants."""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+import apywire
+
+
+def test_basic_constant_expansion() -> None:
+    """Test basic placeholder expansion in constants."""
+    spec: apywire.Spec = {
+        "a": "foo",
+        "b": "{a} bar",
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+    assert wired._values["b"] == "foo bar"
+
+
+def test_nested_constant_dependencies() -> None:
+    """Test nested constant dependencies with correct ordering."""
+    spec: apywire.Spec = {
+        "a": "1",
+        "b": "{a}2",
+        "c": "{b}3",
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+    assert wired._values["a"] == "1"
+    assert wired._values["b"] == "12"
+    assert wired._values["c"] == "123"
+
+
+def test_auto_promoted_constant_with_wired_object() -> None:
+    """Test auto-promotion of constant referencing wired object."""
+    spec: apywire.Spec = {
+        "datetime.datetime now": {"year": 2025, "month": 1, "day": 1},
+        "message": "Time: {now}",
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    # message should be an accessor, not in _values
+    assert "message" not in wired._values
+    assert "message" in wired._parsed
+
+    # Calling the accessor should return formatted string
+    msg = wired.message()
+    assert isinstance(msg, str)
+    assert "2025-01-01" in msg
+
+
+def test_mixed_constant_and_wired_refs() -> None:
+    """Test constant with both constant and wired object references."""
+    spec: apywire.Spec = {
+        "host": "localhost",
+        "datetime.datetime now": {"year": 2025, "month": 6, "day": 15},
+        "status": "Server {host} at {now}",
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    # host should be a constant
+    assert wired._values["host"] == "localhost"
+
+    # status should be auto-promoted (has wired ref)
+    assert "status" not in wired._values
+    assert "status" in wired._parsed
+
+    # Calling the accessor
+    status = wired.status()
+    assert isinstance(status, str)
+    assert "localhost" in status
+    assert "2025" in status
+
+
+def test_circular_dependency_in_constants() -> None:
+    """Test that circular dependencies in constants raise error at init."""
+    spec: apywire.Spec = {
+        "a": "{b}",
+        "b": "{a}",
+    }
+
+    with pytest.raises(apywire.CircularWiringError) as exc_info:
+        apywire.Wiring(spec, thread_safe=False)
+
+    assert "Circular dependency detected in constants" in str(exc_info.value)
+
+
+def test_circular_with_wired_objects() -> None:
+    """Test circular dependency with wired objects (existing behavior)."""
+    # Create mock module for testing
+    mod = ModuleType("test_module")
+
+    class MyClass:
+        def __init__(self, dep: object) -> None:
+            self.dep = dep
+
+    mod.MyClass = MyClass  # type: ignore[attr-defined]
+    sys.modules["test_module"] = mod
+
+    try:
+        spec: apywire.Spec = {
+            "test_module.MyClass a": {"dep": "{b}"},
+            "test_module.MyClass b": {"dep": "{a}"},
+        }
+        wired = apywire.Wiring(spec, thread_safe=False)
+
+        # Should raise when accessed, not at init
+        with pytest.raises(apywire.CircularWiringError):
+            wired.a()
+    finally:
+        del sys.modules["test_module"]
+
+
+def test_complex_nested_structures() -> None:
+    """Test placeholder expansion in nested data structures."""
+    spec: apywire.Spec = {
+        "base": "/app",
+        "config": {"path": "{base}/config.yaml"},
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    assert wired._values["base"] == "/app"
+    assert wired._values["config"] == {"path": "/app/config.yaml"}
+
+
+def test_string_representation_of_wired_object() -> None:
+    """Test that wired objects are converted using str()."""
+    # Create mock module
+    mod = ModuleType("test_module")
+
+    class MyClass:
+        def __str__(self) -> str:
+            return "custom_str"
+
+    mod.MyClass = MyClass  # type: ignore[attr-defined]
+    sys.modules["test_module"] = mod
+
+    try:
+        spec: apywire.Spec = {
+            "test_module.MyClass obj": {},
+            "message": "Object: {obj}",
+        }
+        wired = apywire.Wiring(spec, thread_safe=False)
+
+        result = wired.message()
+        assert result == "Object: custom_str"
+    finally:
+        del sys.modules["test_module"]
+
+
+def test_unknown_constant_placeholder() -> None:
+    """Test that unknown constant placeholder raises error."""
+    spec: apywire.Spec = {
+        "a": "{nonexistent}",
+    }
+
+    with pytest.raises(apywire.UnknownPlaceholderError) as exc_info:
+        apywire.Wiring(spec, thread_safe=False)
+
+    assert "nonexistent" in str(exc_info.value)
+
+
+def test_with_thread_safe_mode() -> None:
+    """Test that constant expansion works in thread-safe mode."""
+    spec: apywire.Spec = {
+        "host": "localhost",
+        "port": 5432,
+        "db_url": "postgresql://{host}:{port}/mydb",
+    }
+    wired = apywire.Wiring(spec, thread_safe=True)
+
+    assert wired._values["db_url"] == "postgresql://localhost:5432/mydb"
+
+
+def test_integer_constant_in_placeholder() -> None:
+    """Test that non-string constants are converted to strings."""
+    spec: apywire.Spec = {
+        "port": 5432,
+        "url": "localhost:{port}",
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    assert wired._values["url"] == "localhost:5432"
+
+
+def test_list_with_placeholders() -> None:
+    """Test placeholder expansion in lists."""
+    spec: apywire.Spec = {
+        "base": "http://api",
+        "endpoints": ["{base}/users", "{base}/posts"],
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    assert wired._values["endpoints"] == [
+        "http://api/users",
+        "http://api/posts",
+    ]
+
+
+def test_no_placeholders() -> None:
+    """Test that constants without placeholders work normally."""
+    spec: apywire.Spec = {
+        "a": "plain string",
+        "b": 42,
+        "c": ["list", "items"],
+    }
+    wired = apywire.Wiring(spec, thread_safe=False)
+
+    assert wired._values["a"] == "plain string"
+    assert wired._values["b"] == 42
+    assert wired._values["c"] == ["list", "items"]
+
+
+def test_compilation_with_placeholders() -> None:
+    """Test that compilation works with placeholder expansion."""
+    spec: apywire.Spec = {
+        "host": "localhost",
+        "port": 5432,
+        "db_url": "postgresql://{host}:{port}/mydb",
+        "datetime.datetime now": {"year": 2025, "month": 1, "day": 1},
+        "message": "DB at {db_url}, time: {now}",
+    }
+
+    # Compile the spec
+    code = apywire.WiringCompiler(spec).compile()
+
+    # Verify constant expansion in compiled code
+    assert "db_url" in code
+    assert "postgresql://localhost:5432/mydb" in code
+
+    # Auto-promoted constants are NOT compiled
+    # (they require runtime interpolation with wired objects)
+    assert "def message" not in code
+
+    # Execute compiled code
+    namespace: dict[str, object] = {}
+    exec(code, namespace)
+
+    # Verify compiled code works (auto-promoted constants are skipped)
+    # Dynamic access not fully type-checked by mypy for exec'd code


### PR DESCRIPTION
  - Allows one constant to use another
  - Automatically promotes a constant to an Accessor if that constant tries to interpolate an object. Will use `__str__` for the object string representation.
  - Tests.

<!--
SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>

SPDX-License-Identifier: ISC
-->
## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Tests pass
- [x] Code formatted
- [ ] Documentation updated