### PR TITLE
Introduce spec generator

### DIFF
--- a/apywire/__init__.py
+++ b/apywire/__init__.py
@@ -11,6 +11,7 @@ from .exceptions import (
     UnknownPlaceholderError,
     WiringError,
 )
+from .generator import Generator
 from .runtime import Accessor, AioAccessor, Spec, SpecEntry, WiringRuntime
 from .threads import ThreadSafeMixin
 from .wiring import WiringBase
@@ -31,4 +32,5 @@ __all__ = [
     "LockUnavailableError",
     "Accessor",
     "AioAccessor",
+    "Generator",
 ]

--- a/apywire/generator.py
+++ b/apywire/generator.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+"""Spec generator from class introspection.
+
+This module provides the Generator class for creating apywire specs
+by inspecting class constructors and their type annotations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from types import ModuleType, NoneType
+from typing import (
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
+
+from apywire.constants import (
+    PLACEHOLDER_END,
+    PLACEHOLDER_START,
+    SPEC_KEY_DELIMITER,
+)
+from apywire.exceptions import CircularWiringError
+from apywire.runtime import _Constructor
+from apywire.wiring import Spec, _ConstantValue, _SpecMapping
+
+# Parameter sentinel values
+_PARAM_EMPTY: object = inspect.Parameter.empty  # type: ignore[misc]
+_VAR_POSITIONAL: object = (
+    inspect.Parameter.VAR_POSITIONAL  # type: ignore[misc]
+)
+_VAR_KEYWORD: object = inspect.Parameter.VAR_KEYWORD  # type: ignore[misc]
+
+
+class Generator:
+    """Generates apywire specs from class introspection.
+
+    This class inspects class constructors to automatically generate
+    spec dictionaries with type-appropriate default values and
+    placeholder references.
+
+    Example:
+        >>> spec = Generator.generate("datetime.datetime now")
+        >>> # Returns spec with now_year, now_month, now_day, etc.
+    """
+
+    # Default values for common types
+    _TYPE_DEFAULTS: dict[type, _ConstantValue] = {
+        int: 0,
+        float: 0.0,
+        str: "",
+        bool: False,
+        bytes: b"",
+        complex: 0j,
+        NoneType: None,
+    }
+
+    @classmethod
+    def generate(cls, *entries: str) -> Spec:
+        """Generate a spec from one or more class entry strings.
+
+        Args:
+            *entries: Entry strings in format "module.Class name" or
+                      "module.Class name.factoryMethod"
+
+        Returns:
+            A spec dictionary suitable for use with apywire.Wiring
+
+        Raises:
+            ValueError: If entry format is invalid
+            CircularWiringError: If circular dependencies detected
+
+        Example:
+            >>> spec = Generator.generate("datetime.datetime now")
+            >>> wired = Wiring(spec)
+        """
+        spec: Spec = {}
+        visited: set[str] = set()
+
+        for entry in entries:
+            cls._process_entry(entry, spec, visited)
+
+        return spec
+
+    @classmethod
+    def _process_entry(cls, entry: str, spec: Spec, visited: set[str]) -> None:
+        """Process a single entry and add it to the spec.
+
+        Args:
+            entry: Entry string like "module.Class name"
+            spec: Spec dict to populate
+            visited: Set of already-visited class keys to detect cycles
+        """
+        module_name, class_name, instance_name, factory_method = (
+            cls._parse_entry(entry)
+        )
+
+        # Build the spec key
+        type_path = f"{module_name}.{class_name}"
+        spec_key = f"{type_path} {instance_name}"
+        if factory_method:
+            spec_key = f"{type_path} {instance_name}.{factory_method}"
+
+        # Check for circular dependency
+        if spec_key in visited:
+            raise CircularWiringError(
+                f"Circular dependency detected: '{spec_key}'"
+            )
+        visited.add(spec_key)
+
+        # Import the class
+        module: ModuleType = importlib.import_module(module_name)
+        target_class: type = cast(type, getattr(module, class_name))
+
+        # Determine what to inspect
+        sig: inspect.Signature
+        try:
+            if factory_method:
+                callable_obj: _Constructor = cast(
+                    _Constructor, getattr(target_class, factory_method)
+                )
+                sig = inspect.signature(callable_obj)
+            else:
+                # For classes, use __init__
+                init_method: _Constructor | None = cast(
+                    _Constructor | None,
+                    getattr(target_class, "__init__", None),
+                )
+                if init_method is not None:
+                    sig = inspect.signature(init_method)
+                else:
+                    spec[spec_key] = {}
+                    return
+        except (ValueError, TypeError):
+            # Some built-in classes don't have inspectable signatures
+            spec[spec_key] = {}
+            return
+
+        # Build params dict for this class
+        params: dict[str, str] = {}
+
+        for param_name, param in sig.parameters.items():
+            # Skip self, cls, *args, **kwargs
+            if param_name in ("self", "cls"):
+                continue
+            param_kind: object = param.kind
+            if param_kind in (_VAR_POSITIONAL, _VAR_KEYWORD):
+                continue
+
+            # Get type annotation
+            annotation: object | None = cast(object | None, param.annotation)
+            if annotation is _PARAM_EMPTY:
+                annotation = None
+
+            # Check if it has a default value
+            param_default: object = cast(object, param.default)
+            has_default = param_default is not _PARAM_EMPTY
+
+            # Generate constant name for this parameter
+            const_name = f"{instance_name}_{param_name}"
+
+            # Determine default value based on type
+            default_value, is_dependency = cls._get_default_for_type(
+                annotation, const_name, spec, visited, module_name
+            )
+
+            placeholder = f"{PLACEHOLDER_START}{const_name}{PLACEHOLDER_END}"
+            params[param_name] = placeholder
+
+            if not is_dependency:
+                # For non-dependency params, set a constant value
+                if has_default and cls._is_constant(param_default):
+                    spec[const_name] = cast(_ConstantValue, param_default)
+                else:
+                    spec[const_name] = default_value
+
+        spec[spec_key] = cast(_SpecMapping, params)
+
+    @classmethod
+    def _parse_entry(cls, entry: str) -> tuple[str, str, str, str | None]:
+        """Parse an entry string into components.
+
+        Args:
+            entry: Entry string like "module.Class name" or
+                   "module.Class name.factoryMethod"
+
+        Returns:
+            Tuple of (module_name, class_name, instance_name, factory_method)
+
+        Raises:
+            ValueError: If entry format is invalid
+        """
+        if SPEC_KEY_DELIMITER not in entry:
+            raise ValueError(
+                f"Invalid entry format '{entry}': "
+                f"expected 'module.Class name'"
+            )
+
+        type_str, name_part = entry.rsplit(SPEC_KEY_DELIMITER, 1)
+        parts = type_str.split(".")
+
+        if len(parts) < 2:
+            raise ValueError(
+                f"Invalid entry format '{entry}': "
+                f"missing module qualification"
+            )
+
+        module_name = ".".join(parts[:-1])
+        class_name = parts[-1]
+
+        # Check for factory method
+        factory_method: str | None = None
+        if "." in name_part:
+            instance_name, factory_method = name_part.split(".", 1)
+        else:
+            instance_name = name_part
+
+        if factory_method and "." in factory_method:
+            raise ValueError(
+                f"invalid generator '{name_part}': nested factory methods "
+                f"are not supported."
+            )
+
+        return module_name, class_name, instance_name, factory_method
+
+    @classmethod
+    def _get_default_for_type(
+        cls,
+        annotation: object,
+        const_name: str,
+        spec: Spec,
+        visited: set[str],
+        current_module: str,
+    ) -> tuple[_ConstantValue, bool]:
+        """Get a default value for a type annotation.
+
+        Args:
+            annotation: The type annotation (may be None)
+            const_name: Name for the constant (used as instance name for deps)
+            spec: Spec dict to populate with dependencies
+            visited: Set of visited class keys for cycle detection
+            current_module: Module name for resolving relative types
+
+        Returns:
+            Tuple of (default_value, is_dependency)
+            - default_value: The constant default value
+            - is_dependency: True if this created a dependency entry
+        """
+        if annotation is None:
+            return None, False
+
+        # Handle typing module constructs
+        origin: object | None = cast(object | None, get_origin(annotation))
+        args: tuple[object, ...] = cast(
+            tuple[object, ...], get_args(annotation)
+        )
+
+        # Optional[X] is Union[X, None]
+        if origin is Union:
+            # Filter out NoneType
+            non_none_args: list[object] = [
+                a for a in args if a is not type(None)
+            ]
+            if len(non_none_args) == 1:
+                # It's Optional[X], recurse with X
+                return cls._get_default_for_type(
+                    non_none_args[0], const_name, spec, visited, current_module
+                )
+            # Complex union, default to None
+            return None, False
+
+        # list, List[T]
+        if origin is list:
+            return cast(_ConstantValue, []), False
+
+        # dict, Dict[K, V]
+        if origin is dict:
+            return cast(_ConstantValue, {}), False
+
+        # tuple, Tuple[...]
+        if origin is tuple:
+            return cast(_ConstantValue, ()), False
+
+        # Check if it's a basic type we know
+        if isinstance(annotation, type):  # type: ignore[misc]
+            if annotation in cls._TYPE_DEFAULTS:
+                return cls._TYPE_DEFAULTS[annotation], False
+
+            # It's a class type - generate as dependency
+            return cls._generate_dependency(
+                annotation,
+                const_name,
+                spec,
+                visited,
+                current_module,
+            )
+
+        # Unknown annotation type
+        return None, False
+
+    @classmethod
+    def _generate_dependency(
+        cls,
+        dep_class: type,
+        instance_name: str,
+        spec: Spec,
+        visited: set[str],
+        current_module: str,
+    ) -> tuple[_ConstantValue, bool]:
+        """Generate a spec entry for a dependency class.
+
+        Args:
+            dep_class: The class to generate
+            instance_name: Instance name for this dependency
+            spec: Spec dict to populate
+            visited: Set of visited class keys
+            current_module: Fallback module name
+
+        Returns:
+            Tuple of (None, True) indicating this is a dependency
+        """
+        class_name = dep_class.__name__
+        module_attr: object | None = getattr(
+            dep_class, "__module__", current_module
+        )
+        if isinstance(module_attr, str) and module_attr:
+            module_name = module_attr
+        else:
+            module_name = current_module
+
+        # Build entry string
+        entry = f"{module_name}.{class_name} {instance_name}"
+
+        # Recursively process (will add to spec)
+        try:
+            cls._process_entry(entry, spec, visited.copy())
+        except (CircularWiringError, AttributeError, ModuleNotFoundError):
+            # If circular or can't find module, just reference it
+            pass
+
+        return None, True
+
+    @classmethod
+    def _is_constant(cls, value: object) -> bool:
+        """Check if a value is a valid constant for a spec.
+
+        Args:
+            value: Value to check
+
+        Returns:
+            True if value can be stored as a spec constant
+        """
+        if value is None or value is ...:
+            return True
+        if isinstance(value, (str, bytes, bool, int, float, complex)):
+            return True
+        if isinstance(value, (list, tuple, dict)):
+            # Check contents recursively
+            if isinstance(value, dict):
+                return all(
+                    cls._is_constant(k) and cls._is_constant(v)
+                    for k, v in value.items()
+                )
+            return all(cls._is_constant(v) for v in value)
+        return False

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -39,6 +39,14 @@ Comprehensive API documentation for apywire.
     options:
       show_source: false
 
+### Generator
+
+::: apywire.Generator
+        options:
+            show_source: false
+            members:
+                - generate
+
 ## Accessor Types
 
 ### Accessor
@@ -222,6 +230,21 @@ code = compiler.compile(aio=True, thread_safe=True)
 
 with open("compiled_wiring.py", "w") as f:
     f.write(code)
+```
+
+### Generator (Spec Generator)
+
+```python
+from apywire import Generator, Wiring
+
+# Generate a spec from a class signature
+spec = Generator.generate("myapp.models.Simple now")
+
+# Override a generated default if needed
+spec["now_year"] = 2025
+
+wired = Wiring(spec)
+now = wired.now()
 ```
 
 ## See Also

--- a/docs/user-guide/generator.md
+++ b/docs/user-guide/generator.md
@@ -1,0 +1,241 @@
+<!--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+
+SPDX-License-Identifier: ISC
+-->
+
+# Generator (Spec Generator)
+
+The Generator utility can create apywire specs by introspecting class constructors.
+It is useful for scaffolding a spec quickly for use with `Wiring` in tests or when
+bootstrapping an application.
+
+## Overview
+
+`Generator` inspects the constructor signature (or a class factory method)
+and generates a spec entry for the given type and instance name. For each
+constructor parameter it creates:
+
+- A placeholder for the parameter, e.g. `{instance_param}`
+- A constant default value in the spec based on the parameter's type (when available)
+- Or a recursive dependency entry if the parameter is another class type
+
+The main entry point is `Generator.generate(*entries)`.
+
+## Usage
+
+Basic usage:
+
+```python
+from apywire import Generator, Wiring
+
+spec = Generator.generate("datetime.datetime now")
+wired = Wiring(spec)
+now = wired.now()
+```
+
+You can generate multiple entries in a single call:
+
+```python
+spec = Generator.generate(
+  "myapp.models.DateClass dt",
+  "myapp.models.DeltaClass delta",
+)
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.models.DateClass dt": {
+    "month": "{dt_month}",
+    "year": "{dt_year}",
+  },
+  "myapp.models.DeltaClass delta": {
+    "days": "{delta_days}",
+  },
+  "dt_month": 0,
+  "dt_year": 0,
+  "delta_days": 0,
+}
+```
+
+Factory methods are supported by adding the factory method to the entry string:
+
+```python
+# Class with @classmethod create(cls, x) -> Instance
+spec = Generator.generate("myapp.factories.WithFactory obj.create")
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.factories.WithFactory obj.create": {
+    "x": "{obj_x}",
+  },
+  "obj_x": 0,
+}
+```
+
+## Behavior and Examples
+
+- Parameter names are converted into placeholders using the instance name:
+  a parameter `year` on instance `now` becomes placeholder `{now_year}`.
+- Primitive and common types receive a sensible constant default:
+  - `int`: 0, `float`: 0.0, `str`: "", `bool`: False, `bytes`: b"",
+    `complex`: 0j, `None`: None
+- `Optional[T]` (i.e., `Union[T, None]`) is resolved to the default for `T`.
+- Complex unions default to `None`.
+- `list`, `dict`, `tuple` defaults are `[]`, `{}`, and `()` respectively.
+- Unknown or missing annotations default to `None`.
+- Non-constant parameter defaults (e.g. object instances) fall back to type defaults.
+- Dependencies (constructor parameters typed as another class) are generated
+  recursively as separate spec entries, unless importing the dependency fails.
+- Circular dependencies may raise `apywire.CircularWiringError` or generate partial
+  specs (tests consider both outcomes acceptable).
+- Built-in types or types whose signatures cannot be inspected may result in an
+  empty `{}` entry for that wiring key.
+
+Example: Simple class
+
+```python
+class Simple:
+    def __init__(self, year: int, month: int, day: int) -> None:
+        ...
+
+spec = Generator.generate("myapp.models.Simple now")
+
+# Example output (spec dictionary):
+expected_spec = {
+    "myapp.models.Simple now": {
+        "year": "{now_year}",
+        "month": "{now_month}",
+        "day": "{now_day}",
+    },
+    "now_year": 0,
+    "now_month": 0,
+    "now_day": 0,
+}
+```
+
+Example: Dependency resolution
+
+```python
+class Inner:
+    def __init__(self, value: int) -> None: ...
+
+class Outer:
+    def __init__(self, inner: Inner) -> None: ...
+
+spec = Generator.generate("myapp.models.Outer wrapper")
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.models.Inner wrapper_inner": {
+    "value": "{wrapper_inner_value}",
+  },
+  "myapp.models.Outer wrapper": {
+    "inner": "{wrapper_inner}",
+  },
+  "wrapper_inner_value": 0,
+}
+```
+
+Example: Typed parameters
+
+```python
+class TypedClass:
+    def __init__(
+        self,
+        int_param: int,
+        str_param: str,
+        float_param: float,
+        bool_param: bool,
+        opt_param: "Optional[str]" = None,
+    ) -> None:
+        pass
+
+spec = Generator.generate("myapp.types.TypedClass obj")
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.types.TypedClass obj": {
+    "int_param": "{obj_int_param}",
+    "str_param": "{obj_str_param}",
+    "float_param": "{obj_float_param}",
+    "bool_param": "{obj_bool_param}",
+    "opt_param": "{obj_opt_param}",
+  },
+  "obj_int_param": 0,
+  "obj_str_param": "",
+  "obj_float_param": 0.0,
+  "obj_bool_param": False,
+  "obj_opt_param": None,
+}
+```
+
+Example: Constant defaults preserved
+
+```python
+class WithDefaults:
+    def __init__(self, name: str = "default_name", count: int = 100) -> None:
+        pass
+
+spec = Generator.generate("myapp.defaults.WithDefaults obj")
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.defaults.WithDefaults obj": {
+    "count": "{obj_count}",
+    "name": "{obj_name}",
+  },
+  "obj_count": 100,
+  "obj_name": "default_name",
+}
+```
+
+Example: List and dict types
+
+```python
+class Container:
+    def __init__(self, items: "List[int]", mapping: "Dict[str, int]") -> None:
+        pass
+
+spec = Generator.generate("myapp.containers.Container c")
+
+# Example output (spec dictionary):
+expected_spec = {
+  "myapp.containers.Container c": {
+    "items": "{c_items}",
+    "mapping": "{c_mapping}",
+  },
+  "c_items": [],
+  "c_mapping": {},
+}
+```
+
+## API
+
+### Generator.generate(*entries: str) -> apywire.Spec
+
+Arguments:
+- `entries`: Strings in the format `module.Class name` or
+  `module.Class name.factoryMethod`.
+
+Returns:
+- A `Spec` dictionary ready for `Wiring`.
+
+Raises:
+- `ValueError` for invalid entry strings (e.g., missing delimiter or module)
+- `apywire.exceptions.CircularWiringError` when a cycle is detected
+
+## Notes and Limitations
+
+- The generator bases decisions on constructor type annotations; without them
+  the generator cannot reliably infer dependencies and will use `None`.
+- For classes that use complex, programmatic defaults or runtime logic, the
+  generator provides initial defaults but you should always review and adjust
+  generated specs to fit runtime requirements.
+- The generated spec is a suggestion and can be altered before passing to
+  `Wiring`. It's useful for tests and bootstrapping but not intended to fully
+  replace manual configuration in production.
+
+## See Also
+
+- `Wiring` (docs/user-guide/basic-usage.md)
+- `apywire.Compiler` and the compiled wiring docs (user-guide/compilation.md)

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -25,6 +25,9 @@ Understand thread-safe instantiation, optimistic locking mechanisms, and configu
 ### [Compilation](compilation.md)
 Learn how to generate standalone Python code from your wiring specs using `WiringCompiler` for production deployment and performance optimization.
 
+### [Spec Generation](generator.md)
+Quickly scaffold wiring specs from class constructor signatures using `Generator`.
+
 ### [Advanced Features](advanced.md)
 Explore advanced capabilities including factory methods, positional arguments, complex nested dependencies, error handling, and best practices.
 
@@ -47,6 +50,7 @@ Looking for something specific?
 - **Multi-threaded app?** → [Thread Safety](thread-safety.md)
 - **Production deployment?** → [Compilation](compilation.md)
 - **Complex use cases?** → [Advanced Features](advanced.md)
+- **Scaffold specs quickly?** → [Spec Generation](generator.md)
 
 ## Common Workflows
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Async Support: user-guide/async-support.md
       - Thread Safety: user-guide/thread-safety.md
       - Compilation: user-guide/compilation.md
+      - Generator: user-guide/generator.md
       - Advanced Features: user-guide/advanced.md
   - API Reference: api-reference.md
   - Examples: examples.md

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,839 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+"""Tests for the Generator class."""
+
+import sys
+from types import ModuleType
+from typing import Optional
+
+from apywire import Generator, Spec, Wiring
+
+
+def test_generate_simple_class() -> None:
+    """Test generating spec for a simple class."""
+
+    class Simple:
+        def __init__(self, year: int, month: int, day: int) -> None:
+            self.year = year
+            self.month = month
+            self.day = day
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_simple")
+            self.Simple = Simple
+
+    mod = MockModule()
+    sys.modules["mockmod_simple"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_simple.Simple now")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_simple.Simple now": {
+                "day": "{now_day}",
+                "month": "{now_month}",
+                "year": "{now_year}",
+            },
+            "now_day": 0,
+            "now_month": 0,
+            "now_year": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_simple" in sys.modules:
+            del sys.modules["mockmod_simple"]
+
+
+def test_generate_multiple_entries() -> None:
+    """Test generating spec for multiple classes at once."""
+
+    class DateClass:
+        def __init__(self, year: int, month: int) -> None:
+            pass
+
+    class DeltaClass:
+        def __init__(self, days: int) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_multi")
+            self.DateClass = DateClass
+            self.DeltaClass = DeltaClass
+
+    mod = MockModule()
+    sys.modules["mockmod_multi"] = mod
+
+    try:
+        spec = Generator.generate(
+            "mockmod_multi.DateClass dt", "mockmod_multi.DeltaClass delta"
+        )
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_multi.DateClass dt": {
+                "month": "{dt_month}",
+                "year": "{dt_year}",
+            },
+            "mockmod_multi.DeltaClass delta": {
+                "days": "{delta_days}",
+            },
+            "dt_month": 0,
+            "dt_year": 0,
+            "delta_days": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_multi" in sys.modules:
+            del sys.modules["mockmod_multi"]
+
+
+def test_generate_with_defaults() -> None:
+    """Test that defaults from class are captured."""
+
+    class WithDefaults:
+        def __init__(
+            self,
+            required: int,
+            hour: int = 0,
+            minute: int = 0,
+            second: int = 0,
+        ) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_defs")
+            self.WithDefaults = WithDefaults
+
+    mod = MockModule()
+    sys.modules["mockmod_defs"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_defs.WithDefaults dt")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_defs.WithDefaults dt": {
+                "hour": "{dt_hour}",
+                "minute": "{dt_minute}",
+                "required": "{dt_required}",
+                "second": "{dt_second}",
+            },
+            "dt_hour": 0,
+            "dt_minute": 0,
+            "dt_required": 0,
+            "dt_second": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_defs" in sys.modules:
+            del sys.modules["mockmod_defs"]
+
+
+def test_generate_invalid_format_no_delimiter() -> None:
+    """Test that invalid entry format raises ValueError."""
+    try:
+        Generator.generate("invalid")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "Invalid entry format" in str(e)
+
+
+def test_generate_invalid_format_no_module() -> None:
+    """Test that entry without module raises ValueError."""
+    try:
+        Generator.generate("Class name")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "missing module qualification" in str(e)
+
+
+def test_generate_invalid_nested_factory_method() -> None:
+    """Test that nested factory methods raise ValueError."""
+    try:
+        Generator.generate("myapp.models.SomeClass inst.create.more")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "nested factory methods" in str(e)
+
+
+def test_generate_with_typed_params() -> None:
+    """Test type-aware default generation."""
+
+    class TypedClass:
+        def __init__(
+            self,
+            int_param: int,
+            str_param: str,
+            float_param: float,
+            bool_param: bool,
+            opt_param: Optional[str] = None,
+        ) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_typed")
+            self.TypedClass = TypedClass
+
+    mod = MockModule()
+    sys.modules["mockmod_typed"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_typed.TypedClass obj")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_typed.TypedClass obj": {
+                "bool_param": "{obj_bool_param}",
+                "float_param": "{obj_float_param}",
+                "int_param": "{obj_int_param}",
+                "opt_param": "{obj_opt_param}",
+                "str_param": "{obj_str_param}",
+            },
+            "obj_bool_param": False,
+            "obj_float_param": 0.0,
+            "obj_int_param": 0,
+            "obj_opt_param": None,
+            "obj_str_param": "",
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_typed" in sys.modules:
+            del sys.modules["mockmod_typed"]
+
+
+def test_generate_with_dependency() -> None:
+    """Test that dependencies are recursively generated."""
+
+    class Inner:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    class Outer:
+        def __init__(self, inner: Inner) -> None:
+            self.inner = inner
+
+    # Set __module__ to point to our mock module
+    Inner.__module__ = "mockmod_dep"
+    Outer.__module__ = "mockmod_dep"
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_dep")
+            self.Inner = Inner
+            self.Outer = Outer
+
+    mod = MockModule()
+    sys.modules["mockmod_dep"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_dep.Outer wrapper")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_dep.Inner wrapper_inner": {
+                "value": "{wrapper_inner_value}",
+            },
+            "mockmod_dep.Outer wrapper": {
+                "inner": "{wrapper_inner}",
+            },
+            "wrapper_inner_value": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_dep" in sys.modules:
+            del sys.modules["mockmod_dep"]
+
+
+def test_generated_spec_works_with_wiring() -> None:
+    """Test that generated spec can be used with Wiring."""
+
+    class Simple:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_wiring")
+            self.Simple = Simple
+
+    mod = MockModule()
+    sys.modules["mockmod_wiring"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_wiring.Simple obj")
+
+        # Modify the generated default
+        spec["obj_value"] = 42
+
+        # Create wiring and test it works
+        wired = Wiring(spec)
+        instance = wired.obj()
+
+        assert isinstance(instance, Simple)
+        assert instance.value == 42
+    finally:
+        if "mockmod_wiring" in sys.modules:
+            del sys.modules["mockmod_wiring"]
+
+
+def test_generate_with_factory_method() -> None:
+    """Test generating spec with factory method."""
+
+    class WithFactory:
+        def __init__(self, a: int, b: str) -> None:
+            self.a = a
+            self.b = b
+
+        @classmethod
+        def create(cls, x: int) -> "WithFactory":
+            return cls(x, "default")
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_factory")
+            self.WithFactory = WithFactory
+
+    mod = MockModule()
+    sys.modules["mockmod_factory"] = mod
+
+    try:
+        # Generate using factory method
+        spec = Generator.generate("mockmod_factory.WithFactory obj.create")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_factory.WithFactory obj.create": {
+                "x": "{obj_x}",
+            },
+            "obj_x": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_factory" in sys.modules:
+            del sys.modules["mockmod_factory"]
+
+
+def test_generate_list_and_dict_types() -> None:
+    """Test handling of list and dict type annotations."""
+    from typing import Dict, List
+
+    class Container:
+        def __init__(
+            self,
+            items: List[int],
+            mapping: Dict[str, int],
+        ) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_container")
+            self.Container = Container
+
+    mod = MockModule()
+    sys.modules["mockmod_container"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_container.Container c")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_container.Container c": {
+                "items": "{c_items}",
+                "mapping": "{c_mapping}",
+            },
+            "c_items": [],
+            "c_mapping": {},
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_container" in sys.modules:
+            del sys.modules["mockmod_container"]
+
+
+def test_generate_no_params() -> None:
+    """Test generating spec for class with no parameters."""
+
+    class NoParams:
+        def __init__(self) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_noparams")
+            self.NoParams = NoParams
+
+    mod = MockModule()
+    sys.modules["mockmod_noparams"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_noparams.NoParams obj")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_noparams.NoParams obj": {},
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_noparams" in sys.modules:
+            del sys.modules["mockmod_noparams"]
+
+
+def test_generate_with_constant_defaults() -> None:
+    """Test that actual constant defaults are preserved."""
+
+    class WithDefaults:
+        def __init__(
+            self,
+            name: str = "default_name",
+            count: int = 100,
+        ) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_defaults")
+            self.WithDefaults = WithDefaults
+
+    mod = MockModule()
+    sys.modules["mockmod_defaults"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_defaults.WithDefaults obj")
+
+        # Use whole-output assertion with expected spec
+        expected_spec: Spec = {
+            "mockmod_defaults.WithDefaults obj": {
+                "count": "{obj_count}",
+                "name": "{obj_name}",
+            },
+            "obj_count": 100,
+            "obj_name": "default_name",
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_defaults" in sys.modules:
+            del sys.modules["mockmod_defaults"]
+
+
+def test_generate_circular_dependency() -> None:
+    """Test that circular dependencies are detected."""
+    from apywire.exceptions import CircularWiringError
+
+    class Node:
+        def __init__(self, child: "Node") -> None:
+            pass
+
+    Node.__module__ = "mockmod_circular"
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_circular")
+            self.Node = Node
+
+    mod = MockModule()
+    sys.modules["mockmod_circular"] = mod
+
+    try:
+        # This should detect circular dependency
+        spec = Generator.generate("mockmod_circular.Node root")
+        # Even with circular deps, it should generate something
+        assert "mockmod_circular.Node root" in spec
+    except CircularWiringError:
+        # This is also acceptable
+        pass
+    finally:
+        if "mockmod_circular" in sys.modules:
+            del sys.modules["mockmod_circular"]
+
+
+def test_generate_class_without_init() -> None:
+    """Test generating spec for class without __init__."""
+
+    class NoInit:
+        pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_noinit")
+            self.NoInit = NoInit
+
+    mod = MockModule()
+    sys.modules["mockmod_noinit"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_noinit.NoInit obj")
+        expected_spec: Spec = {
+            "mockmod_noinit.NoInit obj": {},
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_noinit" in sys.modules:
+            del sys.modules["mockmod_noinit"]
+
+
+def test_generate_builtin_class() -> None:
+    """Test generating spec for built-in class.
+
+    Built-in classes without inspectable signature.
+    """
+    # Built-in classes may raise ValueError/TypeError
+    # This test ensures graceful handling
+    try:
+        spec = Generator.generate("builtins.object obj")
+        # Should generate empty params for uninspectable classes
+        assert "builtins.object obj" in spec
+        assert spec["builtins.object obj"] == {}
+    except Exception:
+        # Some built-ins might not be importable, that's ok
+        pass
+
+
+def test_generate_with_varargs() -> None:
+    """Test handling of *args and **kwargs parameters."""
+
+    class WithVarArgs:
+        def __init__(self, required: int, *args: int, **kwargs: str) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_varargs")
+            self.WithVarArgs = WithVarArgs
+
+    mod = MockModule()
+    sys.modules["mockmod_varargs"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_varargs.WithVarArgs obj")
+        # Should only include 'required', skip *args and **kwargs
+        expected_spec: Spec = {
+            "mockmod_varargs.WithVarArgs obj": {
+                "required": "{obj_required}",
+            },
+            "obj_required": 0,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_varargs" in sys.modules:
+            del sys.modules["mockmod_varargs"]
+
+
+def test_generate_complex_union_type() -> None:
+    """Test handling of complex Union types (not just Optional)."""
+    from typing import Union
+
+    class WithUnion:
+        def __init__(self, value: Union[int, str, float]) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_union")
+            self.WithUnion = WithUnion
+
+    mod = MockModule()
+    sys.modules["mockmod_union"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_union.WithUnion obj")
+        # Complex unions should default to None
+        expected_spec: Spec = {
+            "mockmod_union.WithUnion obj": {
+                "value": "{obj_value}",
+            },
+            "obj_value": None,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_union" in sys.modules:
+            del sys.modules["mockmod_union"]
+
+
+def test_generate_tuple_type() -> None:
+    """Test handling of tuple type annotations."""
+    from typing import Tuple
+
+    class WithTuple:
+        def __init__(self, coords: Tuple[int, int]) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_tuple")
+            self.WithTuple = WithTuple
+
+    mod = MockModule()
+    sys.modules["mockmod_tuple"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_tuple.WithTuple obj")
+        expected_spec: Spec = {
+            "mockmod_tuple.WithTuple obj": {
+                "coords": "{obj_coords}",
+            },
+            "obj_coords": (),  # type: ignore[dict-item]
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_tuple" in sys.modules:
+            del sys.modules["mockmod_tuple"]
+
+
+def test_generate_unknown_annotation() -> None:
+    """Test handling of unknown/complex annotation types."""
+
+    class WithCustom:
+        # Use a non-type annotation that's not in the standard set
+        def __init__(self, value) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_custom")
+            self.WithCustom = WithCustom  # type: ignore[misc]
+
+    mod = MockModule()
+    sys.modules["mockmod_custom"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_custom.WithCustom obj")
+        # Unknown types should default to None
+        expected_spec: Spec = {
+            "mockmod_custom.WithCustom obj": {
+                "value": "{obj_value}",
+            },
+            "obj_value": None,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_custom" in sys.modules:
+            del sys.modules["mockmod_custom"]
+
+
+def test_generate_bytes_and_complex_types() -> None:
+    """Test handling of bytes and complex number types."""
+
+    class WithTypes:
+        def __init__(self, data: bytes, number: complex) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_types")
+            self.WithTypes = WithTypes
+
+    mod = MockModule()
+    sys.modules["mockmod_types"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_types.WithTypes obj")
+        expected_spec: Spec = {
+            "mockmod_types.WithTypes obj": {
+                "data": "{obj_data}",
+                "number": "{obj_number}",
+            },
+            "obj_data": b"",
+            "obj_number": 0j,
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_types" in sys.modules:
+            del sys.modules["mockmod_types"]
+
+
+def test_generate_non_constant_default() -> None:
+    """Test handling of non-constant defaults."""
+
+    class NonConstant:
+        pass
+
+    class WithNonConstant:
+        def __init__(
+            self, obj: int = NonConstant()  # type: ignore[assignment]
+        ) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_nonconst")
+            self.WithNonConstant = WithNonConstant
+
+    mod = MockModule()
+    sys.modules["mockmod_nonconst"] = mod
+
+    try:
+        spec = Generator.generate("mockmod_nonconst.WithNonConstant obj")
+        # Non-constant defaults should use type default
+        expected_spec: Spec = {
+            "mockmod_nonconst.WithNonConstant obj": {
+                "obj": "{obj_obj}",
+            },
+            "obj_obj": 0,  # Should use int default, not the object
+        }
+        assert spec == expected_spec
+    finally:
+        if "mockmod_nonconst" in sys.modules:
+            del sys.modules["mockmod_nonconst"]
+
+
+def test_is_constant_with_collections() -> None:
+    """Test _is_constant with various collection types."""
+    from apywire.generator import Generator
+
+    # Test nested lists and dicts
+    assert Generator._is_constant([1, 2, 3])
+    assert Generator._is_constant({"a": 1, "b": 2})
+    assert Generator._is_constant([1, [2, 3]])
+    assert Generator._is_constant({"a": {"b": 1}})
+    assert Generator._is_constant((1, 2, 3))
+
+    # Test with non-constants
+    class Obj:
+        pass
+
+    assert not Generator._is_constant(Obj())
+    assert not Generator._is_constant([Obj()])
+    assert not Generator._is_constant({"key": Obj()})
+
+    # Test ellipsis
+    assert Generator._is_constant(...)
+
+
+def test_generate_dependency_with_missing_module() -> None:
+    """Test dependency generation when module can't be found."""
+
+    class Inner:
+        def __init__(self, x: int) -> None:
+            pass
+
+    # Set a non-existent module
+    Inner.__module__ = "nonexistent_module_xyz"
+
+    class Outer:
+        def __init__(self, inner: Inner) -> None:
+            pass
+
+    Outer.__module__ = "mockmod_missing"
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_missing")
+            self.Outer = Outer
+
+    mod = MockModule()
+    sys.modules["mockmod_missing"] = mod
+
+    try:
+        # Should handle missing module gracefully
+        spec = Generator.generate("mockmod_missing.Outer obj")
+        # Should still create entry for Outer
+        assert "mockmod_missing.Outer obj" in spec
+    finally:
+        if "mockmod_missing" in sys.modules:
+            del sys.modules["mockmod_missing"]
+
+
+def test_generate_actual_circular_dependency() -> None:
+    """Test that actual circular dependency raises error."""
+    from apywire.exceptions import CircularWiringError
+
+    # Manually create a spec with visited tracking
+    spec: Spec = {}
+    visited: set[str] = {"mockmod_circ.Node root"}
+
+    class Node:
+        def __init__(self, value: int) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_circ")
+            self.Node = Node
+
+    mod = MockModule()
+    sys.modules["mockmod_circ"] = mod
+
+    try:
+        # Try to process entry that's already in visited
+        from apywire.generator import Generator
+
+        Generator._process_entry("mockmod_circ.Node root", spec, visited)
+        assert False, "Should have raised CircularWiringError"
+    except CircularWiringError as e:
+        assert "Circular dependency detected" in str(e)
+    finally:
+        if "mockmod_circ" in sys.modules:
+            del sys.modules["mockmod_circ"]
+
+
+def test_generate_class_with_signature_error() -> None:
+    """Test handling of class that raises error during signature inspection."""
+    import unittest.mock as mock
+
+    class ProblematicClass:
+        def __init__(self, x: int) -> None:
+            pass
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_badsig")
+            self.ProblematicClass = ProblematicClass
+
+    mod = MockModule()
+    sys.modules["mockmod_badsig"] = mod
+
+    try:
+        # Mock inspect.signature to raise ValueError
+        with mock.patch(
+            "inspect.signature", side_effect=ValueError("Bad sig")
+        ):
+            spec = Generator.generate("mockmod_badsig.ProblematicClass obj")
+            # Should generate empty params for signature errors
+            assert "mockmod_badsig.ProblematicClass obj" in spec
+            assert spec["mockmod_badsig.ProblematicClass obj"] == {}
+    finally:
+        if "mockmod_badsig" in sys.modules:
+            del sys.modules["mockmod_badsig"]
+
+
+def test_generate_dependency_with_no_module_attr() -> None:
+    """Test dependency generation when class has no __module__ attribute."""
+
+    class Inner:
+        def __init__(self, x: int) -> None:
+            pass
+
+    # Remove __module__ or set it to None
+    Inner.__module__ = None  # type: ignore[assignment]
+
+    class Outer:
+        def __init__(self, inner: Inner) -> None:
+            pass
+
+    Outer.__module__ = "mockmod_nomodattr"
+
+    class MockModule(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("mockmod_nomodattr")
+            self.Outer = Outer
+            self.Inner = Inner
+
+    mod = MockModule()
+    sys.modules["mockmod_nomodattr"] = mod
+
+    try:
+        # Should use current_module as fallback
+        spec = Generator.generate("mockmod_nomodattr.Outer obj")
+        # Should still create entry for Outer
+        assert "mockmod_nomodattr.Outer obj" in spec
+    finally:
+        if "mockmod_nomodattr" in sys.modules:
+            del sys.modules["mockmod_nomodattr"]


### PR DESCRIPTION
 - Allows you to generate spec dictionaries from one or more class names.
 - Deals with default values, nested instantiation and other edge cases.

<!--
SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>

SPDX-License-Identifier: ISC
-->
## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] Refactoring
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Descriptive and concise commit message and PR details
- [x] Docstrings updated
- [x] Documentation updated
