### PR TITLE
WIP:  Add partials to support circular references 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ reuse:
 		--license ISC \
 		--recursive .
 
-format: reuse
+format:
 	uv run black apywire tests
 	uv run isort apywire tests
 

--- a/apywire/__main__.py
+++ b/apywire/__main__.py
@@ -192,5 +192,5 @@ def main(argv: list[str] | None = None) -> int:
     return func(args)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
     sys.exit(main())

--- a/apywire/exceptions.py
+++ b/apywire/exceptions.py
@@ -34,6 +34,24 @@ class CircularWiringError(WiringError):
     """
 
 
+class PartialConstructionAccessError(WiringError):
+    """Raised when attempting to access or call an object that is still in
+    partial construction (placeholder inserted but not yet finalized).
+
+    This error indicates the wiring is in a transient state and the user
+    attempted to use the placeholder before it was bound to the final
+    instance.
+    """
+
+
+class PartialConstructionError(WiringError):
+    """Raised when partial construction cannot be completed successfully.
+
+    Examples include factories that bypass `__new__` and return a different
+    instance than the skeleton allocated by the wiring system.
+    """
+
+
 class LockUnavailableError(RuntimeError):
     """Exception raised when a per-attribute lock cannot be acquired in
     optimistic (non-blocking) mode and the code must fall back to a global

--- a/apywire/partial.py
+++ b/apywire/partial.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+"""Helpers for partial construction used by compiled containers.
+
+This module contains a small helper that compiled accessors can call to
+preserve partial-construction (skeleton) semantics without depending on
+`apywire.runtime` internals. It is imported only when the compiler is
+configured with `allow_partial=True` so compiled output does
+not include unnecessary runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, List, Optional, Protocol, cast
+
+from apywire.exceptions import CircularWiringError, PartialConstructionError
+
+
+class _ContainerLike(Protocol):
+    _values: dict[str, object] | None
+    _resolving_stack: list[str] | None
+    allow_partial: bool
+
+
+def _compiled_instantiate_with_partial(
+    container: object,
+    name: str,
+    constructor_callable: Callable[[], object],
+    expected_cls: type,
+    is_factory: bool,
+) -> object:  # pragma: no cover
+    # Exercised indirectly via compiler integration
+    """Helper used by compiled accessors to support partial construction.
+
+    See runtime._compiled_instantiate_with_partial for detailed semantics.
+    """
+    # Ensure resolving stack exists
+    stack_existing: object = getattr(container, "_resolving_stack", None)
+    if isinstance(stack_existing, list):
+        stack = cast(List[str], stack_existing)
+    else:
+        stack = []
+        try:
+            setattr(container, "_resolving_stack", stack)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    # Detect cycle; cast container for typing
+    container_obj = cast(_ContainerLike, container)
+    if name in stack:
+        if not container_obj.allow_partial:
+            msg = (
+                "Circular wiring dependency detected: "
+                + " -> ".join(stack)
+                + " -> "
+                + name
+            )
+            raise CircularWiringError(msg)
+        # Allocate skeleton and set partial markers
+        try:
+            # Use __new__ to allocate without invoking __init__
+            new_fn = cast(Callable[[type], object], expected_cls.__new__)
+            skeleton: object = new_fn(expected_cls)
+        except Exception as e:
+            raise PartialConstructionError(
+                "failed to allocate skeleton for %r: %s" % (expected_cls, e)
+            ) from e
+        try:
+            setattr(skeleton, "_apywire_partial", True)
+            setattr(skeleton, "_apywire_event", threading.Event())
+            setattr(skeleton, "_apywire_failure", None)
+        except Exception:  # pragma: no cover - defensive
+            raise PartialConstructionError(
+                f"type {expected_cls} cannot be skeletonized"
+            )
+        # Cache and return skeleton placeholder
+        values = cast(
+            Optional[dict[str, object]],
+            getattr(container_obj, "_values", None),
+        )
+        if values is not None:
+            values[name] = skeleton
+        else:
+            setattr(container, "_" + name, skeleton)
+        return skeleton
+
+    stack.append(name)
+    try:
+        # If a skeleton was inserted by nested resolution, bind to it
+        cached: Optional[object] = None
+        values = cast(
+            Optional[dict[str, object]],
+            getattr(container_obj, "_values", None),
+        )
+        if values is not None:
+            cached = values.get(name)
+        else:
+            cached = cast(
+                Optional[object], getattr(container, "_" + name, None)
+            )
+
+        if cached is not None and cast(
+            bool, getattr(cached, "_apywire_partial", False)
+        ):
+            skeleton = cached
+            try:
+                if is_factory:
+                    # Temporary override of __new__
+                    orig_new: Optional[object] = getattr(
+                        expected_cls, "__new__", None
+                    )
+
+                    def _tmp_new(
+                        _cls: type, *a: object, **k: object
+                    ) -> object:
+                        return skeleton
+
+                    setattr(expected_cls, "__new__", _tmp_new)
+                    try:
+                        ret: object = constructor_callable()
+                    finally:
+                        if orig_new is None:
+                            try:
+                                delattr(expected_cls, "__new__")
+                            except Exception:  # pragma: no cover - defensive
+                                pass
+                        else:
+                            try:
+                                setattr(expected_cls, "__new__", orig_new)
+                            except Exception:
+                                pass
+
+                    if ret is not skeleton:
+                        exc = PartialConstructionError(
+                            "factory for %r returned a different instance "
+                            "than the skeleton" % (name,)
+                        )
+                        try:
+                            setattr(skeleton, "_apywire_failure", exc)
+                            setattr(skeleton, "_apywire_partial", False)
+                            ev = cast(
+                                Optional[threading.Event],
+                                getattr(skeleton, "_apywire_event", None),
+                            )
+                            if ev is not None:
+                                ev.set()
+                        finally:
+                            values_cleanup = cast(
+                                Optional[dict[str, object]],
+                                getattr(container_obj, "_values", None),
+                            )
+                            if (
+                                values_cleanup is not None
+                                and values_cleanup.get(name) is skeleton
+                            ):
+                                del values_cleanup[name]
+                        raise exc
+                    # Success
+                    try:
+                        setattr(skeleton, "_apywire_partial", False)
+                        ev = cast(
+                            Optional[threading.Event],
+                            getattr(skeleton, "_apywire_event", None),
+                        )
+                        if ev is not None:
+                            ev.set()
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    return skeleton
+                else:
+                    # Direct init
+                    try:
+                        init_attr: object = getattr(
+                            expected_cls, "__init__", object.__init__
+                        )
+                        direct_init = cast(
+                            Callable[[object], object | None],
+                            init_attr,
+                        )
+                        direct_init(skeleton)
+                    except Exception as e:
+                        exc = PartialConstructionError(
+                            "failed to initialize skeleton for %r: %s"
+                            % (name, e)
+                        )
+                        try:
+                            setattr(skeleton, "_apywire_failure", exc)
+                            setattr(skeleton, "_apywire_partial", False)
+                            ev = cast(
+                                Optional[threading.Event],
+                                getattr(skeleton, "_apywire_event", None),
+                            )
+                            if ev is not None:
+                                ev.set()
+                        finally:
+                            values_cleanup = cast(
+                                Optional[dict[str, object]],
+                                getattr(container_obj, "_values", None),
+                            )
+                            if (
+                                values_cleanup is not None
+                                and values_cleanup.get(name) is skeleton
+                            ):
+                                del values_cleanup[name]
+                        raise exc from e
+                    try:
+                        setattr(skeleton, "_apywire_partial", False)
+                        ev = cast(
+                            Optional[threading.Event],
+                            getattr(skeleton, "_apywire_event", None),
+                        )
+                        if ev is not None:
+                            ev.set()
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    return skeleton
+            except PartialConstructionError:
+                raise
+            except Exception as e:
+                exc = PartialConstructionError(
+                    f"partial construction failed for '{name}': {e}"
+                )
+                try:
+                    setattr(skeleton, "_apywire_failure", exc)
+                    setattr(skeleton, "_apywire_partial", False)
+                    ev = cast(
+                        Optional[threading.Event],
+                        getattr(skeleton, "_apywire_event", None),
+                    )
+                    if ev is not None:
+                        ev.set()
+                finally:
+                    values_cleanup = cast(
+                        Optional[dict[str, object]],
+                        getattr(container_obj, "_values", None),
+                    )
+                    if (
+                        values_cleanup is not None
+                        and values_cleanup.get(name) is skeleton
+                    ):
+                        del values_cleanup[name]
+                raise exc from e
+
+        # No skeleton present; call constructor normally
+        ret = constructor_callable()
+        # If nested resolution inserted a skeleton, validate and finalize it.
+        cached_now: Optional[object] = None
+        values_now = cast(
+            Optional[dict[str, object]],
+            getattr(container_obj, "_values", None),
+        )
+        if values_now is not None:
+            cached_now = values_now.get(name)
+        else:
+            cached_now = cast(
+                Optional[object], getattr(container, "_" + name, None)
+            )
+        if cached_now is not None and cast(
+            bool, getattr(cached_now, "_apywire_partial", False)
+        ):
+            skeleton = cached_now
+            if ret is not skeleton:
+                # Retry factory with __new__ overridden to return skeleton
+                if is_factory:
+                    orig_new = cast(
+                        object, getattr(expected_cls, "__new__", None)
+                    )
+
+                    def _tmp_new(
+                        _cls: type, *a: object, **k: object
+                    ) -> object:
+                        return skeleton
+
+                    setattr(expected_cls, "__new__", _tmp_new)
+                    try:
+                        retry_ret: object = constructor_callable()
+                    finally:
+                        if orig_new is None:
+                            try:
+                                delattr(expected_cls, "__new__")
+                            except Exception:
+                                pass
+                        else:
+                            try:
+                                setattr(expected_cls, "__new__", orig_new)
+                            except Exception:
+                                pass
+
+                    if retry_ret is not skeleton:
+                        exc = PartialConstructionError(
+                            "factory for %r returned a different instance "
+                            "than the skeleton" % (name,)
+                        )
+                        try:
+                            setattr(skeleton, "_apywire_failure", exc)
+                            setattr(skeleton, "_apywire_partial", False)
+                            ev = cast(
+                                Optional[threading.Event],
+                                getattr(skeleton, "_apywire_event", None),
+                            )
+                            if ev is not None:
+                                ev.set()
+                        finally:
+                            values_cleanup = cast(
+                                Optional[dict[str, object]],
+                                getattr(container_obj, "_values", None),
+                            )
+                            if (
+                                values_cleanup is not None
+                                and values_cleanup.get(name) is skeleton
+                            ):
+                                del values_cleanup[name]
+                        raise exc
+                    # Success on retry
+                    try:
+                        setattr(skeleton, "_apywire_partial", False)
+                        ev = cast(
+                            Optional[threading.Event],
+                            getattr(skeleton, "_apywire_event", None),
+                        )
+                        if ev is not None:
+                            ev.set()
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    return skeleton
+                else:
+                    exc = PartialConstructionError(
+                        "factory for %r returned a different instance "
+                        "than the skeleton" % (name,)
+                    )
+                    try:
+                        setattr(skeleton, "_apywire_failure", exc)
+                        setattr(skeleton, "_apywire_partial", False)
+                        ev = cast(
+                            Optional[threading.Event],
+                            getattr(skeleton, "_apywire_event", None),
+                        )
+                        if ev is not None:
+                            ev.set()
+                    finally:
+                        values_cleanup = cast(
+                            Optional[dict[str, object]],
+                            getattr(container_obj, "_values", None),
+                        )
+                        if (
+                            values_cleanup is not None
+                            and values_cleanup.get(name) is skeleton
+                        ):
+                            del values_cleanup[name]
+                    raise exc
+            else:
+                try:
+                    setattr(skeleton, "_apywire_partial", False)
+                    ev = cast(
+                        Optional[threading.Event],
+                        getattr(skeleton, "_apywire_event", None),
+                    )
+                    if ev is not None:
+                        ev.set()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            return skeleton
+        return ret
+    finally:
+        stack.pop()

--- a/tests/test_compile_partial.py
+++ b/tests/test_compile_partial.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+import sys
+from types import ModuleType
+from typing import Protocol, cast, runtime_checkable
+
+import apywire
+
+
+@runtime_checkable
+class CompPartialModule(Protocol):
+    """Protocol for dynamically created comp_partial module."""
+
+    A: type
+    B: type
+
+
+@runtime_checkable
+class ClassWithDep(Protocol):
+    """Protocol for classes with a dep attribute."""
+
+    dep: object
+
+
+@runtime_checkable
+class CompiledModule(Protocol):
+    """Protocol for compiled wiring module."""
+
+    def a(self) -> ClassWithDep: ...
+    def b(self) -> ClassWithDep: ...
+
+
+def test_compile_partial_factory_identity_preserved_sync() -> None:
+    """Compiled non-async accessors preserve identity for
+    factory-based cycles.
+    """
+
+    class CompPartialModuleImpl(ModuleType):
+        A: type
+        B: type
+
+    mod = CompPartialModuleImpl("comp_partial")
+
+    class A:
+        def __init__(self, dep: object | None = None) -> None:
+            self.dep = dep
+
+        @classmethod
+        def create(cls, dep: object | None = None) -> "A":
+            return cls(dep)
+
+    class B:
+        def __init__(self, dep: object | None = None) -> None:
+            self.dep = dep
+
+        @classmethod
+        def create(cls, dep: object | None = None) -> "B":
+            return cls(dep)
+
+    mod.A = A
+    mod.B = B
+    sys.modules["comp_partial"] = mod
+
+    try:
+        spec: apywire.Spec = {
+            "comp_partial.A a.create": {"dep": "{b}"},
+            "comp_partial.B b.create": {"dep": "{a}"},
+        }
+        compiler = apywire.WiringCompiler(spec, allow_partial=True)
+        code = compiler.compile(aio=False)
+
+        execd: dict[str, object] = {}
+        exec(code, execd)
+        compiled = cast(CompiledModule, execd["compiled"])
+
+        a = compiled.a()
+        b = compiled.b()
+
+        assert a.dep is b
+        assert b.dep is a
+    finally:
+        del sys.modules["comp_partial"]

--- a/tests/test_constant_placeholders.py
+++ b/tests/test_constant_placeholders.py
@@ -95,7 +95,7 @@ def test_circular_dependency_in_constants() -> None:
     with pytest.raises(apywire.CircularWiringError) as exc_info:
         apywire.Wiring(spec, thread_safe=False)
 
-    assert "Circular dependency detected in constants" in str(exc_info.value)
+    assert "Circular wiring dependency detected" in str(exc_info.value)
 
 
 def test_circular_with_wired_objects() -> None:
@@ -115,11 +115,9 @@ def test_circular_with_wired_objects() -> None:
             "test_module.MyClass a": {"dep": "{b}"},
             "test_module.MyClass b": {"dep": "{a}"},
         }
-        wired = apywire.Wiring(spec, thread_safe=False)
-
-        # Should raise when accessed, not at init
+        # Should raise at init time now (no lazy access errors)
         with pytest.raises(apywire.CircularWiringError):
-            wired.a()
+            apywire.Wiring(spec, thread_safe=False)
     finally:
         del sys.modules["test_module"]
 

--- a/tests/test_graph_detection.py
+++ b/tests/test_graph_detection.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+from types import ModuleType
+from typing import Protocol
+
+import pytest
+
+import apywire
+from apywire.exceptions import CircularWiringError
+
+
+class M(ModuleType):
+    def __init__(self) -> None:
+        super().__init__("m")
+
+
+class HasB(Protocol):
+    b: object
+
+
+class HasA(Protocol):
+    a: object
+
+
+class A:
+    def __init__(self, b: HasB) -> None:
+        self.b = b
+
+
+class B:
+    def __init__(self, a: HasA) -> None:
+        self.a = a
+
+
+def test_detect_cycle_between_constant_and_wired() -> None:
+    # constant 'c' references 'w' and wired 'w' references 'c' -> cycle
+    spec: apywire.Spec = {
+        "c": "{w}",
+        "tests.test_graph_detection.A w": {"b": "{c}"},
+    }
+
+    with pytest.raises(CircularWiringError):
+        apywire.Wiring(spec)
+
+
+def test_detect_cycle_mixed_wired_constants() -> None:
+    # Round-trip cycle across multiple entries
+    spec: apywire.Spec = {
+        "a": "{b}",
+        "tests.test_graph_detection.A b": {"b": "{c}"},
+        "c": "{a}",
+    }
+
+    with pytest.raises(CircularWiringError):
+        apywire.Wiring(spec)
+
+
+def test_no_false_positive_for_external_placeholders() -> None:
+    # Placeholder references an external name (not in spec) should not
+    # cause a cycle detection.
+    spec: apywire.Spec = {
+        "a": "{b}",
+        "tests.test_graph_detection.A c": {"b": "foo"},
+    }
+
+    # Should not raise a circular-wiring error; resolving constants will
+    # surface a meaningful UnknownPlaceholderError for missing constant
+    with pytest.raises(apywire.UnknownPlaceholderError):
+        apywire.Wiring(spec)

--- a/tests/test_partial_helper.py
+++ b/tests/test_partial_helper.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+import asyncio
+import threading
+from typing import Callable, cast
+
+import pytest
+
+import apywire
+from apywire.exceptions import CircularWiringError, PartialConstructionError
+from apywire.partial import _compiled_instantiate_with_partial
+from apywire.runtime import Accessor, AioAccessor, _Constructor
+
+
+class _DummyContainer:
+    def __init__(
+        self,
+        *,
+        allow_partial: bool = True,
+        values: dict[str, object] | None = None,
+        stack: list[str] | None = None,
+    ) -> None:
+        self._values = values
+        self._resolving_stack = stack
+        self.allow_partial = allow_partial
+        self._item: object | None = None
+
+
+class _SimpleFactory:
+    _apywire_partial: bool
+    _apywire_event: threading.Event
+    _apywire_failure: Exception | None
+
+    def __init__(self) -> None:
+        self.created = True
+
+    @classmethod
+    def build(cls) -> "_SimpleFactory":
+        return cls()
+
+
+class _ExplodingInit:
+    _apywire_partial: bool
+    _apywire_event: threading.Event
+    _apywire_failure: Exception | None
+
+    def __init__(self) -> None:
+        raise RuntimeError("boom")
+
+
+class _NoAttrs:
+    __slots__ = ()
+
+    def __call__(
+        self, *args: object, **kwargs: object
+    ) -> "_NoAttrs":  # pragma: no cover
+        return self
+
+
+class _LockedSlots:
+    __slots__ = ()
+
+    def __new__(cls) -> "_LockedSlots":
+        return super().__new__(cls)
+
+
+class _Skeleton:
+    def __init__(self, failure: Exception | None = None) -> None:
+        self._apywire_partial = True
+        self._apywire_event = threading.Event()
+        self._apywire_failure = failure
+
+
+def _make_skeleton(
+    ready: bool = False, failure: Exception | None = None
+) -> _Skeleton:
+    skeleton = _Skeleton(failure)
+    if ready:
+        skeleton._apywire_event.set()
+        skeleton._apywire_partial = False
+    return skeleton
+
+
+def test_compiled_partial_rejects_circular_without_opt_in() -> None:
+    container = _DummyContainer(allow_partial=False, values={}, stack=["item"])
+
+    with pytest.raises(CircularWiringError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            lambda: _SimpleFactory.build(),
+            _SimpleFactory,
+            True,
+        )
+
+
+def test_compiled_partial_allocates_and_caches_skeleton() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+
+    skeleton = _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory.build,
+        _SimpleFactory,
+        True,
+    )
+
+    assert isinstance(skeleton, _SimpleFactory)
+    assert container._values == {"item": skeleton}
+    assert skeleton._apywire_partial is True
+    assert skeleton._apywire_event.is_set() is False
+
+    container._resolving_stack = []
+    finalized = _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory.build,
+        _SimpleFactory,
+        True,
+    )
+
+    assert finalized is skeleton
+    assert skeleton._apywire_partial is False
+    assert skeleton._apywire_event.is_set() is True
+
+
+def test_compiled_partial_factory_mismatch_cleans_up() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+    _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory.build,
+        _SimpleFactory,
+        True,
+    )
+    container._resolving_stack = []
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            lambda: object(),
+            _SimpleFactory,
+            True,
+        )
+
+    assert container._values == {}
+
+
+def test_compiled_partial_direct_init_failure_removes_placeholder() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+    _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _ExplodingInit,
+        _ExplodingInit,
+        False,
+    )
+    container._resolving_stack = []
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            _ExplodingInit,
+            _ExplodingInit,
+            False,
+        )
+
+    assert container._values == {}
+
+
+def test_compiled_partial_direct_init_success_with_attr_cache() -> None:
+    container = _DummyContainer(values=None, stack=["item"])
+    _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory,
+        _SimpleFactory,
+        False,
+    )
+    container._resolving_stack = []
+
+    result = _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory,
+        _SimpleFactory,
+        False,
+    )
+
+    assert isinstance(result, _SimpleFactory)
+    assert result is container._item
+    assert result._apywire_partial is False
+
+
+def test_compiled_partial_new_failure_raises() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+
+    class NewBoom:
+        def __new__(cls) -> "NewBoom":
+            raise RuntimeError("nope")
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            lambda: NewBoom(),
+            NewBoom,
+            False,
+        )
+
+
+def test_compiled_partial_marker_injection_failure() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            _LockedSlots,
+            _LockedSlots,
+            False,
+        )
+
+
+def test_compiled_partial_cached_factory_generic_error_cleans_up() -> None:
+    container = _DummyContainer(values={}, stack=["item"])
+    _compiled_instantiate_with_partial(
+        container,
+        "item",
+        _SimpleFactory.build,
+        _SimpleFactory,
+        True,
+    )
+    container._resolving_stack = []
+
+    def _raise() -> object:
+        raise RuntimeError("bang")
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            _raise,
+            _SimpleFactory,
+            True,
+        )
+
+    assert container._values == {}
+
+
+def test_compiled_partial_late_skeleton_mismatch_raises() -> None:
+    container = _DummyContainer(values={}, stack=[])
+    late_skeleton = _make_skeleton()
+    container._values = {}
+
+    def _constructor() -> object:
+        values = container._values
+        assert values is not None
+        values["item"] = late_skeleton
+        return _SimpleFactory()
+
+    with pytest.raises(PartialConstructionError):
+        _compiled_instantiate_with_partial(
+            container,
+            "item",
+            _constructor,
+            _SimpleFactory,
+            False,
+        )
+
+    assert container._values == {}
+
+
+def test_compiled_partial_normal_instantiation_without_skeleton() -> None:
+    container = _DummyContainer(values={}, stack=[])
+    marker = object()
+
+    ret = _compiled_instantiate_with_partial(
+        container,
+        "item",
+        lambda: marker,
+        _SimpleFactory,
+        False,
+    )
+
+    assert ret is marker
+
+
+def test_runtime_skeletonize_type_errors_on_new_failure() -> None:
+    class NewFails:
+        def __new__(cls) -> "NewFails":
+            raise RuntimeError("fail new")
+
+        def __call__(self, *args: object, **kwargs: object) -> object:
+            raise RuntimeError("never called")
+
+    wiring = apywire.Wiring({})
+
+    bad_ctor = cast(_Constructor, NewFails)
+
+    with pytest.raises(PartialConstructionError):
+        wiring._skeletonize_type(bad_ctor)
+
+
+def test_runtime_skeletonize_type_errors_when_markers_forbidden() -> None:
+    wiring = apywire.Wiring({})
+
+    ctor = cast(_Constructor, _NoAttrs)
+
+    with pytest.raises(PartialConstructionError):
+        wiring._skeletonize_type(ctor)
+
+
+def test_runtime_finalize_records_failure_and_signals_event() -> None:
+    wiring = apywire.Wiring({})
+    skeleton = _make_skeleton()
+    failure = ValueError("bad")
+
+    wiring._finalize_skeleton(skeleton, failure)
+
+    assert skeleton._apywire_failure is failure
+    assert skeleton._apywire_partial is False
+    assert skeleton._apywire_event.is_set()
+
+
+def test_accessor_waits_and_raises_failure() -> None:
+    wiring = apywire.Wiring({})
+    skeleton = _make_skeleton(failure=RuntimeError("fail"))
+    skeleton._apywire_event.set()
+    wiring._values["item"] = skeleton
+    accessor = Accessor(wiring, "item")
+
+    with pytest.raises(RuntimeError):
+        accessor()
+
+
+def test_aio_accessor_waits_and_propagates_failure() -> None:
+    wiring = apywire.Wiring({})
+    skeleton = _make_skeleton(failure=RuntimeError("fail"))
+    skeleton._apywire_event.set()
+    wiring._values["item"] = skeleton
+    aio_accessor = AioAccessor(wiring)
+
+    async def _call() -> None:
+        await aio_accessor.item()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(_call())
+
+
+@pytest.mark.parametrize("constructor", [int, lambda: 42])
+def test_compiled_partial_handles_plain_construction(
+    constructor: Callable[[], object],
+) -> None:
+    container = _DummyContainer(values={}, stack=[])
+
+    result = _compiled_instantiate_with_partial(
+        container,
+        "plain",
+        constructor,
+        int,
+        False,
+    )
+
+    assert result is not None

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import Protocol, cast
 
 import black
+import pytest
 
 import apywire
 
@@ -649,14 +650,9 @@ def test_circular_reference_raises() -> None:
             "mymod_circ.A a": {"b": "{b}"},
             "mymod_circ.B b": {"a": "{a}"},
         }
-        wired: apywire.Wiring = apywire.Wiring(spec, thread_safe=False)
-        try:
-            _ = wired.a()
-            assert (
-                False
-            ), "Should have raised CircularWiringError for circular dependency"
-        except apywire.CircularWiringError as e:
-            assert "Circular wiring dependency detected" in str(e)
+        with pytest.raises(apywire.CircularWiringError) as exc_info:
+            apywire.Wiring(spec, thread_safe=False)
+        assert "Circular wiring dependency detected" in str(exc_info.value)
     finally:
         if "mymod_circ" in sys.modules:
             del sys.modules["mymod_circ"]

--- a/uv.lock.license
+++ b/uv.lock.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+
+SPDX-License-Identifier: ISC


### PR DESCRIPTION
⚠️  WORK IN PROGRESS ⚠️ 

 - Implements `allow_partial` opt-in feature that permits specs with circular dependencies to be constructed.
 - Move circular dependency detection when `allow_partial=false` to `WiringBase` constructor.

 - [x] Initial PoC
 - [ ] Remove and stash unrelated tests added just to reach 95% coverage
 - [ ] Reach 95% coverage by covering the new features
 - [x] ~Refactoring~ (will be dealt with in a separate PR)
 - [x] ~Docs~ (will be dealt with in a separate PR)

