### PR TITLE
Streamline REUSE licenses

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
-
-SPDX-License-Identifier: ISC
--->
 ---
 name: Bug Report
 about: Report a bug
@@ -20,5 +15,6 @@ Steps to reproduce.
 What should happen.
 
 **Environment**
-- OS: 
+- OS:
 - Python version:
+- apywire version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
-
-SPDX-License-Identifier: ISC
--->
 ---
 name: Feature Request
 about: Suggest a new feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
-
-SPDX-License-Identifier: ISC
--->
-## Description
-
-Brief description of changes.
-
 ## Type of Change
 
 - [ ] Bug fix
@@ -14,9 +5,3 @@ Brief description of changes.
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Documentation update
-
-## Checklist
-
-- [ ] Descriptive and concise commit message and PR details
-- [ ] Docstrings updated
-- [ ] Documentation updated

--- a/.vscode/extensions.json.license
+++ b/.vscode/extensions.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
-
-SPDX-License-Identifier: ISC

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
-
-SPDX-License-Identifier: ISC

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,3 +16,8 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 Alexandre Gomes Gaigalas <alganet@gmail.com>"
 SPDX-License-Identifier = "ISC"
 
+[[annotations]]
+path = [ ".vscode/**", ".github/PULL_REQUEST_TEMPLATE.md", ".github/ISSUE_TEMPLATE/**" ]
+SPDX-FileCopyrightText = "2025 Alexandre Gomes Gaigalas <alganet@gmail.com>"
+SPDX-License-Identifier = "ISC"
+


### PR DESCRIPTION
 - Remove in-file SPDX from GitHub templates, as they appear in the UI and are annoying. Move them to REUSE.toml instead.
 - Remove .license files for .vscode JSONs.
