### PR TITLE
Guard __getattr__ against recursion when internal state is absent

### DIFF
--- a/apywire/runtime.py
+++ b/apywire/runtime.py
@@ -101,8 +101,31 @@ class WiringRuntime(WiringBase, ThreadSafeMixin):
 
     def __getattr__(self, name: str) -> Accessor:
         """Return a callable accessor for the named wired object."""
+        # Read internal state from __dict__ directly. __getattr__ only runs
+        # when normal lookup fails, so referencing self._parsed/self._values
+        # here would re-enter __getattr__ and recurse forever whenever they
+        # are absent (e.g. during copy/unpickle or a partially-failed
+        # __init__). Failing cleanly with AttributeError lets those protocols
+        # work and keeps errors meaningful.
+        # object.__getattribute__ does the normal C-level lookup and raises
+        # AttributeError directly if the attribute is absent, WITHOUT calling
+        # __getattr__ again -- so missing internal state fails cleanly instead
+        # of recursing.
+        try:
+            parsed = cast(
+                "dict[str, object]",
+                object.__getattribute__(self, "_parsed"),
+            )
+            values = cast(
+                "dict[str, object]",
+                object.__getattribute__(self, "_values"),
+            )
+        except AttributeError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
         # If the name is in our parsed spec or constants, return an accessor.
-        if name in self._parsed or name in self._values:
+        if name in parsed or name in values:
             return Accessor(self, name)
         raise AttributeError(
             f"'{type(self).__name__}' object has no attribute '{name}'"
@@ -371,13 +394,20 @@ class AioAccessor:
 
     def __getattr__(self, name: str) -> Callable[[], Awaitable[object]]:
         """Return an async callable for the named wired object."""
-        # Check if valid name
-        if (
-            name not in self._wiring._parsed
-            and name not in self._wiring._values
-        ):
+        # Read _wiring from __dict__ to avoid recursing through __getattr__
+        # if this accessor isn't fully initialized.
+        try:
+            wiring = cast(
+                WiringRuntime, object.__getattribute__(self, "_wiring")
+            )
+        except AttributeError:
             raise AttributeError(
-                f"'{type(self._wiring).__name__}' object has no attribute "
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
+        # Check if valid name
+        if name not in wiring._parsed and name not in wiring._values:
+            raise AttributeError(
+                f"'{type(wiring).__name__}' object has no attribute "
                 f"'{name}'"
             )
 
@@ -415,8 +445,18 @@ class CompiledAio:
 
     def __getattr__(self, name: str) -> Callable[[], Awaitable[object]]:
         """Return an async callable for the named accessor."""
+        # Read _compiled from __dict__ to avoid recursing through __getattr__
+        # if this wrapper isn't fully initialized.
+        try:
+            compiled = cast(
+                object, object.__getattribute__(self, "_compiled")
+            )
+        except AttributeError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
         method: Callable[[], object] = cast(
-            Callable[[], object], getattr(self._compiled, name)
+            Callable[[], object], getattr(compiled, name)
         )
         cache_attr = f"{CACHE_ATTR_PREFIX}{name}"
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -663,3 +663,70 @@ def test_runtime_format_string_constant_unknown_placeholder() -> None:
     # Template with unknown placeholder
     with pytest.raises(UnknownPlaceholderError, match="Unknown placeholder"):
         wired._format_string_constant("Value: {unknown}", "test_context")
+
+
+def test_getattr_on_uninitialized_runtime_raises_attribute_error() -> None:
+    """An uninitialized WiringRuntime fails cleanly, not with recursion.
+
+    __getattr__ runs only when normal lookup fails; if it referenced
+    self._parsed/self._values while those are absent (copy, unpickle, or a
+    partially-failed __init__) it would re-enter __getattr__ and recurse
+    forever. It must raise AttributeError instead.
+    """
+    from apywire.runtime import WiringRuntime
+
+    obj = WiringRuntime.__new__(WiringRuntime)
+    for probe in ("foo", "_parsed", "_values"):
+        with pytest.raises(AttributeError):
+            getattr(obj, probe)
+
+
+def test_getattr_on_uninitialized_aio_accessor_raises_attribute_error() -> (
+    None
+):
+    """An uninitialized AioAccessor fails cleanly, not with recursion."""
+    from apywire.runtime import AioAccessor
+
+    obj = AioAccessor.__new__(AioAccessor)
+    for probe in ("foo", "_wiring"):
+        with pytest.raises(AttributeError):
+            getattr(obj, probe)
+
+
+def test_getattr_on_uninitialized_compiled_aio_raises_attribute_error() -> (
+    None
+):
+    """An uninitialized CompiledAio fails cleanly, not with recursion."""
+    from apywire.runtime import CompiledAio
+
+    obj = CompiledAio.__new__(CompiledAio)
+    for probe in ("foo", "_compiled"):
+        with pytest.raises(AttributeError):
+            getattr(obj, probe)
+
+
+def test_underscore_prefixed_wired_name_still_accessible() -> None:
+    """The recursion guard must not block legitimately underscore-named
+    entries, which are resolved through _values at runtime.
+    """
+    import sys
+    from types import ModuleType
+
+    from apywire import Spec, Wiring
+
+    class Thing:
+        def __init__(self) -> None:
+            self.ok = True
+
+    mod = ModuleType("mod_underscore_name")
+    mod.Thing = Thing  # type: ignore[attr-defined]
+    sys.modules["mod_underscore_name"] = mod
+    try:
+        spec: Spec = {"mod_underscore_name.Thing _hidden": {}}
+        wired = Wiring(spec, thread_safe=False)
+        inst = wired._hidden()
+        assert isinstance(inst, Thing)
+        # Cached on second access.
+        assert wired._hidden() is inst
+    finally:
+        del sys.modules["mod_underscore_name"]


### PR DESCRIPTION
WiringRuntime, AioAccessor and CompiledAio each dereferenced their own instance state (self._parsed/_values, self._wiring, self._compiled) inside __getattr__. Because __getattr__ only runs after normal lookup fails, those references re-entered __getattr__ and recursed to RecursionError whenever the state was missing -- e.g. during copy, unpickle, or a partially-failed __init__.

All three now read internal state via object.__getattribute__, which performs the normal lookup, raises AttributeError directly when the attribute is absent, and does not invoke __getattr__ again. Missing state now fails cleanly with AttributeError instead of recursing.

object.__getattribute__ (rather than a leading-underscore name guard) is used so legitimately underscore-prefixed wired entries remain accessible, and it avoids referencing self.__dict__ (typed dict[str, Any]) which mypy strict rejects under disallow_any_expr.

Adds regression tests for each class plus one confirming underscore-prefixed wired names still resolve.
