### PR TITLE
Normalize PEP 604 X | None unions in the Generator

### DIFF
--- a/apywire/generator.py
+++ b/apywire/generator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from types import ModuleType, NoneType
+from types import ModuleType, NoneType, UnionType
 from typing import (
     Union,
     cast,
@@ -216,8 +216,11 @@ class Generator(SpecParser):
             tuple[object, ...], get_args(annotation)
         )
 
-        # Optional[X] is Union[X, None]
-        if origin is Union:
+        # Optional[X] / Union[X, None] (typing.Union) and the PEP 604 form
+        # X | None (types.UnionType). On Python < 3.14 get_origin returns a
+        # different object for each spelling, so both must be matched for
+        # `X | None` to be normalized like Optional[X].
+        if origin is Union or origin is UnionType:
             # Filter out NoneType
             non_none_args: list[object] = [
                 a for a in args if a is not type(None)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -169,6 +169,11 @@ def test_generate_invalid_formats(entry: str, expected_msg: str) -> None:
         (bytes, b""),
         (complex, 0j),
         (None, None),  # unknown annotation
+        # PEP 604 X | None must behave like Optional[X]. (Multi-arg unions
+        # yield None regardless of spelling/version, so the Union[...] case
+        # above already covers that path.)
+        (int | None, 0),
+        (str | None, ""),
     ],
     ids=[
         "int",
@@ -183,6 +188,8 @@ def test_generate_invalid_formats(entry: str, expected_msg: str) -> None:
         "bytes",
         "complex",
         "unknown",
+        "pep604_optional_int",
+        "pep604_optional_str",
     ],
 )
 def test_generate_type_defaults(


### PR DESCRIPTION
_get_default_for_type matched only `origin is Union`. typing.Optional[X] and Union[X, None] have get_origin == typing.Union, but the PEP 604 form X | None has get_origin == types.UnionType on Python 3.12/3.13, so those parameters were not normalized like Optional[X] (e.g. an `int | None` parameter with no default produced None instead of 0). Python 3.14 unified the two, masking the divergence.

Match both origins so X | None behaves identically to Optional[X] on every supported version. Adds `int | None` and `str | None` cases to the type-default parametrization; they pass trivially on 3.14 and exercise the fix on the 3.12/3.13 CI runners.
