### PR TITLE
Reject non-contiguous positional argument keys at construction

### DIFF
--- a/apywire/wiring.py
+++ b/apywire/wiring.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 from collections import deque
+from collections.abc import Iterable
 from types import EllipsisType
 from typing import NamedTuple, TypeAlias, cast
 
@@ -163,6 +164,35 @@ class SpecParser:
             )
 
         return module_name, class_name, name, factory_method
+
+    @staticmethod
+    def _validate_positional_keys(
+        name: str, keys: Iterable[str | int]
+    ) -> None:
+        """Ensure positional (integer) argument keys are contiguous from 0.
+
+        Integer keys in an entry's data are positional constructor
+        arguments. They are sorted by index before being passed positionally,
+        so a gap (e.g. ``{0: ..., 2: ...}``) or a non-zero start would
+        silently shift arguments into the wrong slots. Require a contiguous
+        ``0..n-1`` run and raise otherwise.
+
+        Args:
+            name: Exposed entry name, for the error message.
+            keys: The entry's data keys (string keys are ignored).
+
+        Raises:
+            ValueError: If the integer keys are not a contiguous run from 0.
+        """
+        int_keys = sorted(k for k in keys if isinstance(k, int))
+        if not int_keys:
+            return
+        if int_keys != list(range(len(int_keys))):
+            raise ValueError(
+                f"invalid spec entry '{name}': positional argument keys "
+                f"must be a contiguous sequence starting at 0, "
+                f"got {int_keys}"
+            )
 
     @staticmethod
     def _is_spec_constant(value: object) -> bool:
@@ -334,6 +364,14 @@ class WiringBase(SpecParser):
                 None,
                 cast(str | _WiredRef, self._resolve(wired_val)),
             )
+
+        # Validate positional argument keys up front. Synthetic entries carry
+        # constant values rather than argument mappings, so they are skipped.
+        for arg_name, arg_entry in self._parsed.items():
+            if arg_entry.module_name == SYNTHETIC_CONST:
+                continue
+            if isinstance(arg_entry.data, dict):
+                self._validate_positional_keys(arg_name, arg_entry.data)
 
     def _parse_spec_entry(
         self, key: str, value: _SpecMapping | _ConstantValue

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from typing import Protocol, cast
 
 import black
+import pytest
 
 import apywire
 
@@ -643,6 +644,42 @@ def test_empty_module_name_raises() -> None:
         assert False, "Should have raised ValueError for empty module name"
     except ValueError as e:
         assert "invalid spec key 'Class name'" in str(e)
+
+
+def test_positional_arg_gap_raises_at_construction() -> None:
+    """A gap in positional (integer) keys is rejected eagerly.
+
+    {0: ..., 2: ...} (missing index 1) would silently pass two positional
+    args, shifting the intended third argument into the second slot.
+    """
+    spec: apywire.Spec = {"datetime.date d": {0: 2023, 2: 27}}
+    with pytest.raises(ValueError, match="contiguous sequence starting at 0"):
+        apywire.Wiring(spec, thread_safe=False)
+
+
+def test_positional_arg_nonzero_start_raises() -> None:
+    """Positional keys that do not start at 0 are rejected."""
+    spec: apywire.Spec = {"datetime.date d": {1: 2023, 2: 27}}
+    with pytest.raises(ValueError, match="contiguous sequence starting at 0"):
+        apywire.Wiring(spec, thread_safe=False)
+
+
+def test_positional_arg_gap_rejected_by_compiler_too() -> None:
+    """The compiler rejects the same malformed spec at construction.
+
+    Runtime and compiled paths share WiringBase.__init__, so both fail fast
+    and identically.
+    """
+    spec: apywire.Spec = {"datetime.date d": {0: 2023, 2: 27}}
+    with pytest.raises(ValueError, match="contiguous sequence starting at 0"):
+        apywire.WiringCompiler(spec)
+
+
+def test_contiguous_positional_args_are_accepted() -> None:
+    """A complete 0..n-1 positional run instantiates normally."""
+    spec: apywire.Spec = {"datetime.date d": {0: 2023, 1: 10, 2: 27}}
+    wired = apywire.Wiring(spec, thread_safe=False)
+    assert wired.d() == datetime.date(2023, 10, 27)
 
 
 def test_unknown_placeholder_exception_during_creation() -> None:


### PR DESCRIPTION
Integer keys in an entry's data are positional constructor arguments, sorted by index before being passed positionally. A gap (e.g. {0: ..., 2: ...}) or a non-zero start silently shifted arguments into the wrong slots instead of failing.

WiringBase.__init__ now validates that each real entry's integer keys form a contiguous 0..n-1 run via a shared _validate_positional_keys helper, raising ValueError otherwise. Validating at the shared parse point makes it fail fast and covers both the runtime and the compiler (both inherit __init__) without duplicating the check in their separate argument-processing methods. Synthetic promoted-constant entries carry constant values, not argument mappings, and are skipped.

Adds tests for a gap and a non-zero start (runtime), the same rejection via WiringCompiler, and a contiguous run that still instantiates.
