### PR TITLE
Reject entry names that collide with another entry's cache attribute

### DIFF
--- a/apywire/wiring.py
+++ b/apywire/wiring.py
@@ -23,6 +23,7 @@ from types import EllipsisType
 from typing import NamedTuple, TypeAlias, cast
 
 from apywire.constants import (
+    CACHE_ATTR_PREFIX,
     PLACEHOLDER_END,
     PLACEHOLDER_REGEX,
     PLACEHOLDER_START,
@@ -193,6 +194,35 @@ class SpecParser:
                 f"must be a contiguous sequence starting at 0, "
                 f"got {int_keys}"
             )
+
+    @staticmethod
+    def _validate_no_cache_collisions(exposed: set[str]) -> None:
+        """Reject names that collide with another entry's cache attribute.
+
+        Wired and promoted-constant entries cache their instantiated value
+        under ``<CACHE_ATTR_PREFIX><name>`` (e.g. ``foo`` caches as ``_foo``).
+        If another entry is literally named ``_foo`` it collides: in compiled
+        and thread-safe containers the cache lookup (``hasattr(self, '_foo')``
+        or the generated ``_foo`` method) shadows the real value, so ``foo()``
+        silently returns the wrong object. Plain runtime keys by name and is
+        unaffected, which makes the failure a runtime/compiled divergence.
+        Reject the ambiguity up front, in every mode.
+
+        Args:
+            exposed: All exposed entry names (wired, constant and promoted).
+
+        Raises:
+            ValueError: If two names differ only by a leading cache prefix.
+        """
+        for name in sorted(exposed):
+            cache_attr = f"{CACHE_ATTR_PREFIX}{name}"
+            if cache_attr in exposed:
+                raise ValueError(
+                    f"spec entry '{name}' caches as '{cache_attr}', which "
+                    f"collides with another entry named '{cache_attr}'; "
+                    f"names differing only by a leading "
+                    f"'{CACHE_ATTR_PREFIX}' are not allowed."
+                )
 
     @staticmethod
     def _is_spec_constant(value: object) -> bool:
@@ -372,6 +402,11 @@ class WiringBase(SpecParser):
                 continue
             if isinstance(arg_entry.data, dict):
                 self._validate_positional_keys(arg_name, arg_entry.data)
+
+        # Reject names that collide with another entry's cache attribute.
+        self._validate_no_cache_collisions(
+            set(self._parsed) | set(self._values)
+        )
 
     def _parse_spec_entry(
         self, key: str, value: _SpecMapping | _ConstantValue

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -152,6 +152,37 @@ wired = Wiring(spec)
 dt = wired.dt()  # datetime.datetime(2025, 1, 1, hour=12, minute=30)
 ```
 
+### Positional Argument Keys Must Be Contiguous
+
+Numeric keys are positional arguments and must form a contiguous run
+starting at `0` (`0, 1, 2, …`). A gap or a non-zero start would silently
+shift arguments into the wrong slots, so it is rejected when the container
+is created:
+
+```python
+# ❌ Raises ValueError: missing index 1 would shift the arguments
+Wiring({"datetime.date d": {0: 2023, 2: 27}})
+```
+
+## Reserved Names
+
+Each wired entry caches its instantiated value under an attribute prefixed
+with an underscore (`foo` caches as `_foo`). Because of this, **two entries
+whose names differ only by a leading underscore are not allowed** — naming
+one entry `foo` and another `_foo` would make `foo`'s cache collide with the
+`_foo` entry. This is rejected when the container is created:
+
+```python
+# ❌ Raises ValueError: '_foo' collides with the cache attribute of 'foo'
+Wiring({
+    "myapp.A foo": {},
+    "myapp.B _foo": {},
+})
+```
+
+A single underscore-prefixed name on its own (with no bare counterpart) is
+fine.
+
 ## Complex Nested Dependencies
 
 ### Deep Dependency Chains

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -682,6 +682,48 @@ def test_contiguous_positional_args_are_accepted() -> None:
     assert wired.d() == datetime.date(2023, 10, 27)
 
 
+def test_cache_attribute_collision_raises() -> None:
+    """Two entries differing only by a leading '_' are rejected.
+
+    'foo' caches as '_foo'; an entry literally named '_foo' collides, which
+    silently breaks foo() in compiled and thread-safe containers (the cache
+    lookup shadows the real value). It is rejected at construction.
+    """
+    spec: apywire.Spec = {
+        "datetime.date foo": {0: 2023, 1: 1, 2: 1},
+        "datetime.date _foo": {0: 2024, 1: 2, 2: 2},
+    }
+    with pytest.raises(ValueError, match="collides with another entry"):
+        apywire.Wiring(spec, thread_safe=False)
+
+
+def test_cache_attribute_collision_with_constant_raises() -> None:
+    """The collision is detected against constants too."""
+    spec: apywire.Spec = {
+        "datetime.date foo": {0: 2023, 1: 1, 2: 1},
+        "_foo": 42,
+    }
+    with pytest.raises(ValueError, match="collides with another entry"):
+        apywire.Wiring(spec, thread_safe=False)
+
+
+def test_cache_attribute_collision_rejected_by_compiler_too() -> None:
+    """The compiler rejects the colliding spec at construction as well."""
+    spec: apywire.Spec = {
+        "datetime.date foo": {0: 2023, 1: 1, 2: 1},
+        "datetime.date _foo": {0: 2024, 1: 2, 2: 2},
+    }
+    with pytest.raises(ValueError, match="collides with another entry"):
+        apywire.WiringCompiler(spec)
+
+
+def test_underscore_name_without_collision_is_allowed() -> None:
+    """A lone underscore-prefixed entry (no bare counterpart) is fine."""
+    spec: apywire.Spec = {"datetime.date _only": {0: 2023, 1: 1, 2: 1}}
+    wired = apywire.Wiring(spec, thread_safe=False)
+    assert wired._only() == datetime.date(2023, 1, 1)
+
+
 def test_unknown_placeholder_exception_during_creation() -> None:
     """If creating a referenced attribute raises AttributeError, the
     resolution should translate that into a meaningful 'unknown


### PR DESCRIPTION
Wired and promoted-constant entries cache their instantiated value under <CACHE_ATTR_PREFIX><name> (foo caches as _foo). A spec defining both foo and _foo collides, and the breakage is a silent runtime/compiled divergence:

- compiled foo() returns the bound _foo method, because hasattr(self, '_foo') is always true (the generated _foo method shadows the cache check);
- thread-safe runtime foo() returns an Accessor, because _check_cache does hasattr(self, '_foo'), which __getattr__ resolves to the _foo entry;
- plain runtime keys by name in _values and is unaffected.

WiringBase.__init__ now rejects any pair of names differing only by a leading cache prefix via _validate_no_cache_collisions, in every mode, so the ambiguity cannot reach compilation or thread-safe execution. A lone underscore-prefixed name with no bare counterpart is still allowed.

Documents the reserved-name rule (and the positional-key contiguity rule from the previous change) in the advanced user guide.
