### PR TITLE
Replace O(V·E) toposort rescan with reverse-adjacency map

### DIFF
--- a/apywire/wiring.py
+++ b/apywire/wiring.py
@@ -540,14 +540,20 @@ class WiringBase(SpecParser):
         Raises:
             CircularWiringError: If circular dependencies detected
         """
-        # Calculate in-degree (number of dependencies) for each node
-        # Pre-convert to set for efficient intersection
+        # Calculate in-degree (number of dependencies) for each node and
+        # build the reverse adjacency (dependents-of) map in a single pass.
+        # Dependents are appended in node-iteration order, so a node's list
+        # preserves the original dict insertion order and the dequeue order
+        # below stays identical to a per-node rescan of ``dependencies``.
         all_nodes = set(dependencies.keys())
         in_degree: dict[str, int] = {}
+        dependents: dict[str, list[str]] = {node: [] for node in dependencies}
         for node, deps in dependencies.items():
             # Filter to only dependencies within this set
             internal_deps = deps & all_nodes
             in_degree[node] = len(internal_deps)
+            for dep in internal_deps:
+                dependents[dep].append(node)
 
         # Start with nodes that have no dependencies (within this set)
         queue: deque[str] = deque(
@@ -559,12 +565,11 @@ class WiringBase(SpecParser):
             node = queue.popleft()
             result.append(node)
 
-            # Find nodes that depend on this node (within this set)
-            for other_node, deps in dependencies.items():
-                if node in deps:
-                    in_degree[other_node] -= 1
-                    if in_degree[other_node] == 0:
-                        queue.append(other_node)
+            # Decrement in-degree of nodes that depend on this one
+            for other_node in dependents[node]:
+                in_degree[other_node] -= 1
+                if in_degree[other_node] == 0:
+                    queue.append(other_node)
 
         # If we couldn't process all nodes, there's a cycle
         if len(result) != len(dependencies):

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -60,3 +60,38 @@ def test_astify_tuple_and_fallback_to_constant() -> None:
     # ast.Constant.value is typed as a union of constant types, but we're
     # testing the fallback behavior, so we cast to object for the check
     assert cast(object, const_node.value) is d
+
+
+def test_topological_sort_orders_dependencies_first() -> None:
+    w = apywire.Wiring({}, thread_safe=False)
+    # c depends on b, b depends on a; result must list each dep before its
+    # dependent and be deterministic.
+    deps = {"c": {"b"}, "b": {"a"}, "a": set()}
+    order = w._topological_sort(deps)
+    assert order == ["a", "b", "c"]
+    # External (out-of-set) references are ignored for ordering.
+    assert w._topological_sort({"a": {"external"}}) == ["a"]
+
+
+def test_topological_sort_deterministic_for_independent_nodes() -> None:
+    w = apywire.Wiring({}, thread_safe=False)
+    # Multiple roots and a shared dependent. Zero-degree roots are emitted in
+    # insertion order (a, b, c); d becomes ready once b is processed and is
+    # appended behind the already-queued c. The exact sequence is pinned so a
+    # regression that reorders output (and would change compiled-output bytes)
+    # fails here rather than silently passing.
+    deps = {"a": set(), "b": set(), "d": {"a", "b"}, "c": set()}
+    assert w._topological_sort(deps) == ["a", "b", "c", "d"]
+    # Reordering the insertion order reorders the output correspondingly.
+    reordered = {"c": set(), "b": set(), "a": set(), "d": {"a", "b"}}
+    assert w._topological_sort(reordered) == ["c", "b", "a", "d"]
+
+
+def test_topological_sort_raises_on_cycle() -> None:
+    import pytest
+
+    from apywire.exceptions import CircularWiringError
+
+    w = apywire.Wiring({}, thread_safe=False)
+    with pytest.raises(CircularWiringError):
+        w._topological_sort({"a": {"b"}, "b": {"a"}})


### PR DESCRIPTION
_topological_sort ran Kahn's algorithm but found each dequeued node's dependents by rescanning the entire dependencies dict on every pop, making it O(V·E) on the spec graph. Build the reverse-adjacency (dependents-of) map once during the in-degree pass and walk only a node's dependents on dequeue, giving O(V+E).

Output order is unchanged: dependents are appended in node-iteration order, so each list preserves the original dict insertion order and the dequeue sequence is byte-identical to the old per-node rescan (verified against the old algorithm across chain, diamond, multi-root, external-ref and deep-linear graphs). Compiled output therefore stays identical.

Add direct tests pinning the exact emitted order for two insertion orders so a future reordering regression fails CI.
