### PR TITLE
Declare the Cython module safe to run without the GIL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,15 @@ def add_spdx_header(c_file):
 if os.path.exists("apywire/wiring.c"):
     os.remove("apywire/wiring.c")
 
-ext_modules = cythonize("apywire/wiring.py", force=True)
+# wiring.py holds no mutable module-level state: its globals are TypeAliases
+# and every mutable attribute is per-instance. Declaring Py_mod_gil as
+# NOT_USED keeps free-threaded interpreters from re-enabling the GIL
+# process-wide when apywire is imported.
+ext_modules = cythonize(
+    "apywire/wiring.py",
+    force=True,
+    compiler_directives={"freethreading_compatible": True},
+)
 
 # Add SPDX header to the generated .c file
 if os.path.exists("apywire/wiring.c"):

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -8,7 +8,9 @@ These tests verify thread-safe instantiation, locking behavior, and
 concurrent access patterns.
 """
 
+import subprocess
 import sys
+import sysconfig
 import threading
 from types import ModuleType
 from typing import Awaitable, Protocol, cast
@@ -828,3 +830,35 @@ def test_optimistic_mode_cleanup() -> None:
     assert container._local.mode is None
     assert container._get_held_locks() == []
     assert result == "test"
+
+
+FREE_THREADED: bool = bool(
+    cast(object, sysconfig.get_config_var("Py_GIL_DISABLED"))
+)
+
+
+@pytest.mark.skipif(
+    not FREE_THREADED,
+    reason="requires a free-threaded (Py_GIL_DISABLED) build",
+)
+def test_import_does_not_reenable_the_gil() -> None:
+    """Importing apywire must leave free-threading on.
+
+    The Cython extension declares Py_mod_gil as NOT_USED. Without that
+    declaration a free-threaded interpreter re-enables the GIL for the
+    whole process the moment apywire.wiring is imported, silently
+    serializing every other thread in the host application.
+
+    Checked in a subprocess: by the time this test runs the module is
+    already imported, so an in-process assertion would observe the
+    damage as the status quo and pass.
+    """
+    probe = "import apywire, sys; print(sys._is_gil_enabled())"
+    result = subprocess.run(
+        [sys.executable, "-W", "error::RuntimeWarning", "-c", probe],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False", result.stderr


### PR DESCRIPTION
On a free-threaded build, importing apywire re-enabled the GIL for the whole process. Py_mod_gil is not a label: an extension that does not declare it makes the interpreter turn the GIL back on globally, so any application that imported apywire lost free-threading everywhere, not just inside apywire. The reported RuntimeWarning was the symptom.

Cython already emits the Py_mod_gil slot; it defaulted to GIL_USED because nothing told it otherwise. The freethreading_compatible directive sets it to NOT_USED.

The declaration is true, not just a way to silence the warning. wiring.py is the only compiled module, and its module-level state is nothing but TypeAliases -- no cdef classes, no freelists, no global caches. Every mutable attribute is per-instance and written only in __init__, and the locking machinery in threads.py is pure Python and uncompiled. Sixteen threads building and resolving containers in true parallelism run clean.

The test asserts a fresh interpreter still has the GIL disabled after importing apywire. It has to spawn one: by the time an in-process assertion runs, apywire is already imported, so it would read the damage as the status quo and pass.
